### PR TITLE
Remove active mode

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,137 @@
+Language:        Cpp
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 2000
+PointerAlignment: Right
+RawStringFormats:
+  - Language:        Cpp
+    Delimiters:
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions:
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    false
+SortUsingDeclarations: false
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        2
+UseTab:          Never

--- a/components/mitsubishi_itp/climate.py
+++ b/components/mitsubishi_itp/climate.py
@@ -19,7 +19,6 @@ DEPENDENCIES = [
 CONF_UART_HEATPUMP = "uart_heatpump"
 CONF_UART_THERMOSTAT = "uart_thermostat"
 
-CONF_DISABLE_ACTIVE_MODE = "disable_active_mode"
 CONF_ENHANCED_MHK_SUPPORT = (
     "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
 )
@@ -48,7 +47,6 @@ CONFIG_SCHEMA = climate.CLIMATE_SCHEMA.extend(
         cv.Optional(CONF_CUSTOM_FAN_MODES, default=["VERYHIGH"]): cv.ensure_list(
             validate_custom_fan_modes
         ),
-        cv.Optional(CONF_DISABLE_ACTIVE_MODE, default=False): cv.boolean,
         cv.Optional(CONF_ENHANCED_MHK_SUPPORT, default=False): cv.boolean,
         cv.Optional(CONF_RECALL_SETPOINT, default=False): cv.boolean,
     }
@@ -119,9 +117,6 @@ async def to_code(config):
         cg.add(traits.set_supported_custom_fan_modes(config[CONF_CUSTOM_FAN_MODES]))
 
     # Debug Settings
-    if dam_conf := config.get(CONF_DISABLE_ACTIVE_MODE):
-        cg.add(getattr(mitp_component, "set_active_mode")(not dam_conf))
-
     if enhanced_mhk_protocol := config.get(CONF_ENHANCED_MHK_SUPPORT):
         cg.add(
             getattr(mitp_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol)

--- a/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -1,130 +1,147 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome {
-namespace mitsubishi_itp {
+namespace esphome
+{
+  namespace mitsubishi_itp
+  {
 
-// Called to instruct a change of the climate controls
-void MitsubishiUART::control(const climate::ClimateCall &call) {
-  if (!active_mode_)
-    return;  // If we're not in active mode, ignore control requests
+    // Called to instruct a change of the climate controls
+    void MitsubishiUART::control(const climate::ClimateCall &call)
+    {
 
-  SettingsSetRequestPacket set_request_packet = SettingsSetRequestPacket();
+      SettingsSetRequestPacket set_request_packet = SettingsSetRequestPacket();
 
-  // Apply fan settings
-  // Prioritize a custom fan mode if it's set.
-  if (call.get_custom_fan_mode().has_value()) {
-    if (call.get_custom_fan_mode().value() == FAN_MODE_VERYHIGH) {
-      set_custom_fan_mode_(FAN_MODE_VERYHIGH);
-      set_request_packet.set_fan(SettingsSetRequestPacket::FAN_4);
-    }
-  } else if (call.get_fan_mode().has_value()) {
-    switch (call.get_fan_mode().value()) {
-      case climate::CLIMATE_FAN_QUIET:
-        set_fan_mode_(climate::CLIMATE_FAN_QUIET);
-        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_QUIET);
-        break;
-      case climate::CLIMATE_FAN_LOW:
-        set_fan_mode_(climate::CLIMATE_FAN_LOW);
-        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_1);
-        break;
-      case climate::CLIMATE_FAN_MEDIUM:
-        set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
-        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_2);
-        break;
-      case climate::CLIMATE_FAN_HIGH:
-        set_fan_mode_(climate::CLIMATE_FAN_HIGH);
-        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_3);
-        break;
-      case climate::CLIMATE_FAN_AUTO:
-        set_fan_mode_(climate::CLIMATE_FAN_AUTO);
-        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_AUTO);
-        break;
-      default:
-        ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
-        break;
-    }
-  }
-
-  // Mode
-
-  if (call.get_mode().has_value()) {
-    mode = call.get_mode().value();
-
-    switch (call.get_mode().value()) {
-      case climate::CLIMATE_MODE_HEAT_COOL:
-        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_AUTO);
-        break;
-      case climate::CLIMATE_MODE_COOL:
-        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_COOL);
-        break;
-      case climate::CLIMATE_MODE_HEAT:
-        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_HEAT);
-        break;
-      case climate::CLIMATE_MODE_FAN_ONLY:
-        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_FAN);
-        break;
-      case climate::CLIMATE_MODE_DRY:
-        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_DRY);
-        break;
-      case climate::CLIMATE_MODE_OFF:
-      default:
-        set_request_packet.set_power(false);
-        break;
-    }
-  }
-
-  // Target Temperature
-
-  if (call.get_target_temperature().has_value()) {
-    target_temperature = call.get_target_temperature().value();
-    set_request_packet.set_target_temperature(call.get_target_temperature().value());
-  } else if (call.get_mode().has_value()) {
-    // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
-    auto previous_target = mode_recall_setpoints_[call.get_mode().value()];
-    if (previous_target > 0) {
-      ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
-      target_temperature = previous_target;
-      set_request_packet.set_target_temperature(previous_target);
-    }
-  }
-
-  if (call.get_target_temperature().has_value() || call.get_mode().has_value()) {
-    // update our MHK tracking setpoints accordingly
-    switch (mode) {
-      case climate::CLIMATE_MODE_COOL:
-      case climate::CLIMATE_MODE_DRY:
-        this->mhk_state_.cool_setpoint_ = target_temperature;
-        break;
-      case climate::CLIMATE_MODE_HEAT:
-        this->mhk_state_.heat_setpoint_ = target_temperature;
-        break;
-      case climate::CLIMATE_MODE_HEAT_COOL:
-        if (this->get_traits().get_supports_two_point_target_temperature()) {
-          this->mhk_state_.cool_setpoint_ = target_temperature_low;
-          this->mhk_state_.heat_setpoint_ = target_temperature_high;
-        } else {
-          // HACK: This is not accurate, but it's good enough for testing.
-          this->mhk_state_.cool_setpoint_ = target_temperature + 2;
-          this->mhk_state_.heat_setpoint_ = target_temperature - 2;
+      // Apply fan settings
+      // Prioritize a custom fan mode if it's set.
+      if (call.get_custom_fan_mode().has_value())
+      {
+        if (call.get_custom_fan_mode().value() == FAN_MODE_VERYHIGH)
+        {
+          set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_4);
         }
-      default:
-        break;
+      }
+      else if (call.get_fan_mode().has_value())
+      {
+        switch (call.get_fan_mode().value())
+        {
+        case climate::CLIMATE_FAN_QUIET:
+          set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_QUIET);
+          break;
+        case climate::CLIMATE_FAN_LOW:
+          set_fan_mode_(climate::CLIMATE_FAN_LOW);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_1);
+          break;
+        case climate::CLIMATE_FAN_MEDIUM:
+          set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_2);
+          break;
+        case climate::CLIMATE_FAN_HIGH:
+          set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_3);
+          break;
+        case climate::CLIMATE_FAN_AUTO:
+          set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_AUTO);
+          break;
+        default:
+          ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
+          break;
+        }
+      }
+
+      // Mode
+
+      if (call.get_mode().has_value())
+      {
+        mode = call.get_mode().value();
+
+        switch (call.get_mode().value())
+        {
+        case climate::CLIMATE_MODE_HEAT_COOL:
+          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_AUTO);
+          break;
+        case climate::CLIMATE_MODE_COOL:
+          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_COOL);
+          break;
+        case climate::CLIMATE_MODE_HEAT:
+          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_HEAT);
+          break;
+        case climate::CLIMATE_MODE_FAN_ONLY:
+          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_FAN);
+          break;
+        case climate::CLIMATE_MODE_DRY:
+          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_DRY);
+          break;
+        case climate::CLIMATE_MODE_OFF:
+        default:
+          set_request_packet.set_power(false);
+          break;
+        }
+      }
+
+      // Target Temperature
+
+      if (call.get_target_temperature().has_value())
+      {
+        target_temperature = call.get_target_temperature().value();
+        set_request_packet.set_target_temperature(call.get_target_temperature().value());
+      }
+      else if (call.get_mode().has_value())
+      {
+        // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
+        auto previous_target = mode_recall_setpoints_[call.get_mode().value()];
+        if (previous_target > 0)
+        {
+          ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
+          target_temperature = previous_target;
+          set_request_packet.set_target_temperature(previous_target);
+        }
+      }
+
+      if (call.get_target_temperature().has_value() || call.get_mode().has_value())
+      {
+        // update our MHK tracking setpoints accordingly
+        switch (mode)
+        {
+        case climate::CLIMATE_MODE_COOL:
+        case climate::CLIMATE_MODE_DRY:
+          this->mhk_state_.cool_setpoint_ = target_temperature;
+          break;
+        case climate::CLIMATE_MODE_HEAT:
+          this->mhk_state_.heat_setpoint_ = target_temperature;
+          break;
+        case climate::CLIMATE_MODE_HEAT_COOL:
+          if (this->get_traits().get_supports_two_point_target_temperature())
+          {
+            this->mhk_state_.cool_setpoint_ = target_temperature_low;
+            this->mhk_state_.heat_setpoint_ = target_temperature_high;
+          }
+          else
+          {
+            // HACK: This is not accurate, but it's good enough for testing.
+            this->mhk_state_.cool_setpoint_ = target_temperature + 2;
+            this->mhk_state_.heat_setpoint_ = target_temperature - 2;
+          }
+        default:
+          break;
+        }
+      }
+
+      // TODO:
+      // Vane
+      // HVane?
+      // Swing?
+
+      // We're assuming that every climate call *does* make some change worth sending to the heat pump
+      // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
+      hp_bridge_.send_packet(set_request_packet);
+
+      // Publish state and any sensor changes (shouldn't be any a result of this function, but
+      // since they lazy-publish, no harm in trying)
+      do_publish_();
     }
-  }
 
-  // TODO:
-  // Vane
-  // HVane?
-  // Swing?
-
-  // We're assuming that every climate call *does* make some change worth sending to the heat pump
-  // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
-  hp_bridge_.send_packet(set_request_packet);
-
-  // Publish state and any sensor changes (shouldn't be any a result of this function, but
-  // since they lazy-publish, no harm in trying)
-  do_publish_();
-}
-
-}  // namespace mitsubishi_itp
-}  // namespace esphome
+  } // namespace mitsubishi_itp
+} // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -1,147 +1,127 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome
-{
-  namespace mitsubishi_itp
-  {
+namespace esphome {
+namespace mitsubishi_itp {
 
-    // Called to instruct a change of the climate controls
-    void MitsubishiUART::control(const climate::ClimateCall &call)
-    {
+// Called to instruct a change of the climate controls
+void MitsubishiUART::control(const climate::ClimateCall &call) {
+  SettingsSetRequestPacket set_request_packet = SettingsSetRequestPacket();
 
-      SettingsSetRequestPacket set_request_packet = SettingsSetRequestPacket();
-
-      // Apply fan settings
-      // Prioritize a custom fan mode if it's set.
-      if (call.get_custom_fan_mode().has_value())
-      {
-        if (call.get_custom_fan_mode().value() == FAN_MODE_VERYHIGH)
-        {
-          set_custom_fan_mode_(FAN_MODE_VERYHIGH);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_4);
-        }
-      }
-      else if (call.get_fan_mode().has_value())
-      {
-        switch (call.get_fan_mode().value())
-        {
-        case climate::CLIMATE_FAN_QUIET:
-          set_fan_mode_(climate::CLIMATE_FAN_QUIET);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_QUIET);
-          break;
-        case climate::CLIMATE_FAN_LOW:
-          set_fan_mode_(climate::CLIMATE_FAN_LOW);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_1);
-          break;
-        case climate::CLIMATE_FAN_MEDIUM:
-          set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_2);
-          break;
-        case climate::CLIMATE_FAN_HIGH:
-          set_fan_mode_(climate::CLIMATE_FAN_HIGH);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_3);
-          break;
-        case climate::CLIMATE_FAN_AUTO:
-          set_fan_mode_(climate::CLIMATE_FAN_AUTO);
-          set_request_packet.set_fan(SettingsSetRequestPacket::FAN_AUTO);
-          break;
-        default:
-          ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
-          break;
-        }
-      }
-
-      // Mode
-
-      if (call.get_mode().has_value())
-      {
-        mode = call.get_mode().value();
-
-        switch (call.get_mode().value())
-        {
-        case climate::CLIMATE_MODE_HEAT_COOL:
-          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_AUTO);
-          break;
-        case climate::CLIMATE_MODE_COOL:
-          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_COOL);
-          break;
-        case climate::CLIMATE_MODE_HEAT:
-          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_HEAT);
-          break;
-        case climate::CLIMATE_MODE_FAN_ONLY:
-          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_FAN);
-          break;
-        case climate::CLIMATE_MODE_DRY:
-          set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_DRY);
-          break;
-        case climate::CLIMATE_MODE_OFF:
-        default:
-          set_request_packet.set_power(false);
-          break;
-        }
-      }
-
-      // Target Temperature
-
-      if (call.get_target_temperature().has_value())
-      {
-        target_temperature = call.get_target_temperature().value();
-        set_request_packet.set_target_temperature(call.get_target_temperature().value());
-      }
-      else if (call.get_mode().has_value())
-      {
-        // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
-        auto previous_target = mode_recall_setpoints_[call.get_mode().value()];
-        if (previous_target > 0)
-        {
-          ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
-          target_temperature = previous_target;
-          set_request_packet.set_target_temperature(previous_target);
-        }
-      }
-
-      if (call.get_target_temperature().has_value() || call.get_mode().has_value())
-      {
-        // update our MHK tracking setpoints accordingly
-        switch (mode)
-        {
-        case climate::CLIMATE_MODE_COOL:
-        case climate::CLIMATE_MODE_DRY:
-          this->mhk_state_.cool_setpoint_ = target_temperature;
-          break;
-        case climate::CLIMATE_MODE_HEAT:
-          this->mhk_state_.heat_setpoint_ = target_temperature;
-          break;
-        case climate::CLIMATE_MODE_HEAT_COOL:
-          if (this->get_traits().get_supports_two_point_target_temperature())
-          {
-            this->mhk_state_.cool_setpoint_ = target_temperature_low;
-            this->mhk_state_.heat_setpoint_ = target_temperature_high;
-          }
-          else
-          {
-            // HACK: This is not accurate, but it's good enough for testing.
-            this->mhk_state_.cool_setpoint_ = target_temperature + 2;
-            this->mhk_state_.heat_setpoint_ = target_temperature - 2;
-          }
-        default:
-          break;
-        }
-      }
-
-      // TODO:
-      // Vane
-      // HVane?
-      // Swing?
-
-      // We're assuming that every climate call *does* make some change worth sending to the heat pump
-      // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
-      hp_bridge_.send_packet(set_request_packet);
-
-      // Publish state and any sensor changes (shouldn't be any a result of this function, but
-      // since they lazy-publish, no harm in trying)
-      do_publish_();
+  // Apply fan settings
+  // Prioritize a custom fan mode if it's set.
+  if (call.get_custom_fan_mode().has_value()) {
+    if (call.get_custom_fan_mode().value() == FAN_MODE_VERYHIGH) {
+      set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+      set_request_packet.set_fan(SettingsSetRequestPacket::FAN_4);
     }
+  } else if (call.get_fan_mode().has_value()) {
+    switch (call.get_fan_mode().value()) {
+      case climate::CLIMATE_FAN_QUIET:
+        set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_QUIET);
+        break;
+      case climate::CLIMATE_FAN_LOW:
+        set_fan_mode_(climate::CLIMATE_FAN_LOW);
+        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_1);
+        break;
+      case climate::CLIMATE_FAN_MEDIUM:
+        set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_2);
+        break;
+      case climate::CLIMATE_FAN_HIGH:
+        set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_3);
+        break;
+      case climate::CLIMATE_FAN_AUTO:
+        set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+        set_request_packet.set_fan(SettingsSetRequestPacket::FAN_AUTO);
+        break;
+      default:
+        ESP_LOGW(TAG, "Unhandled fan mode %i!", call.get_fan_mode().value());
+        break;
+    }
+  }
 
-  } // namespace mitsubishi_itp
-} // namespace esphome
+  // Mode
+
+  if (call.get_mode().has_value()) {
+    mode = call.get_mode().value();
+
+    switch (call.get_mode().value()) {
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_AUTO);
+        break;
+      case climate::CLIMATE_MODE_COOL:
+        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_COOL);
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_HEAT);
+        break;
+      case climate::CLIMATE_MODE_FAN_ONLY:
+        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_FAN);
+        break;
+      case climate::CLIMATE_MODE_DRY:
+        set_request_packet.set_power(true).set_mode(SettingsSetRequestPacket::MODE_BYTE_DRY);
+        break;
+      case climate::CLIMATE_MODE_OFF:
+      default:
+        set_request_packet.set_power(false);
+        break;
+    }
+  }
+
+  // Target Temperature
+
+  if (call.get_target_temperature().has_value()) {
+    target_temperature = call.get_target_temperature().value();
+    set_request_packet.set_target_temperature(call.get_target_temperature().value());
+  } else if (call.get_mode().has_value()) {
+    // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
+    auto previous_target = mode_recall_setpoints_[call.get_mode().value()];
+    if (previous_target > 0) {
+      ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
+      target_temperature = previous_target;
+      set_request_packet.set_target_temperature(previous_target);
+    }
+  }
+
+  if (call.get_target_temperature().has_value() || call.get_mode().has_value()) {
+    // update our MHK tracking setpoints accordingly
+    switch (mode) {
+      case climate::CLIMATE_MODE_COOL:
+      case climate::CLIMATE_MODE_DRY:
+        this->mhk_state_.cool_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        this->mhk_state_.heat_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        if (this->get_traits().get_supports_two_point_target_temperature()) {
+          this->mhk_state_.cool_setpoint_ = target_temperature_low;
+          this->mhk_state_.heat_setpoint_ = target_temperature_high;
+        } else {
+          // HACK: This is not accurate, but it's good enough for testing.
+          this->mhk_state_.cool_setpoint_ = target_temperature + 2;
+          this->mhk_state_.heat_setpoint_ = target_temperature - 2;
+        }
+      default:
+        break;
+    }
+  }
+
+  // TODO:
+  // Vane
+  // HVane?
+  // Swing?
+
+  // We're assuming that every climate call *does* make some change worth sending to the heat pump
+  // Queue the packet to be sent first (so any subsequent update packets come *after* our changes)
+  hp_bridge_.send_packet(set_request_packet);
+
+  // Publish state and any sensor changes (shouldn't be any a result of this function, but
+  // since they lazy-publish, no harm in trying)
+  do_publish_();
+}
+
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -1,377 +1,434 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome {
-namespace mitsubishi_itp {
+namespace esphome
+{
+  namespace mitsubishi_itp
+  {
 
-void MitsubishiUART::route_packet_(const Packet &packet) {
-  // If the packet is associated with the thermostat and just came from the thermostat, send it to the heatpump
-  // If it came from the heatpump, send it back to the thermostat
-  if (packet.get_controller_association() == ControllerAssociation::THERMOSTAT) {
-    if (packet.get_source_bridge() == SourceBridge::THERMOSTAT) {
-      hp_bridge_.send_packet(packet);
-    } else if (packet.get_source_bridge() == SourceBridge::HEATPUMP) {
-      ts_bridge_->send_packet(packet);
+    void MitsubishiUART::route_packet_(const Packet &packet)
+    {
+      // If the packet is associated with the thermostat and just came from the thermostat, send it to the heatpump
+      // If it came from the heatpump, send it back to the thermostat
+      if (packet.get_controller_association() == ControllerAssociation::THERMOSTAT)
+      {
+        if (packet.get_source_bridge() == SourceBridge::THERMOSTAT)
+        {
+          hp_bridge_.send_packet(packet);
+        }
+        else if (packet.get_source_bridge() == SourceBridge::HEATPUMP)
+        {
+          ts_bridge_->send_packet(packet);
+        }
+      }
     }
-  }
-}
 
-// Packet Handlers
-void MitsubishiUART::process_packet(const Packet &packet) {
-  ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
-  ESP_LOGD(TAG, "%s", packet.to_string().c_str());
-  route_packet_(packet);
-}
-
-void MitsubishiUART::process_packet(const ConnectRequestPacket &packet) {
-  // Nothing to be done for these except forward them along from thermostat to heat pump.
-  // This method defined so that these packets are not "unhandled"
-  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-  route_packet_(packet);
-}
-void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  // Not sure if there's any needed content in this response, so assume we're connected.
-  hp_connected_ = true;
-  ESP_LOGI(TAG, "Heatpump connected.");
-}
-
-void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet) {
-  // Nothing to be done for these except forward them along from thermostat to heat pump.
-  // This method defined so that these packets are not "unhandled"
-  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-  route_packet_(packet);
-}
-void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  // Not sure if there's any needed content in this response, so assume we're connected.
-  // TODO: Is there more useful info in these?
-  hp_connected_ = true;
-  capabilities_cache_ = packet;
-  ESP_LOGI(TAG, "Received heat pump identification packet.");
-}
-
-void MitsubishiUART::process_packet(const GetRequestPacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-
-  switch (packet.get_requested_command()) {
-    case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
-      this->handle_thermostat_state_download_request(packet);
-      break;
-    case GetCommand::THERMOSTAT_GET_AB:
-      this->handle_thermostat_ab_get_request(packet);
-      break;
-    default:
+    // Packet Handlers
+    void MitsubishiUART::process_packet(const Packet &packet)
+    {
+      ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
+      ESP_LOGD(TAG, "%s", packet.to_string().c_str());
       route_packet_(packet);
-  }
-}
+    }
 
-void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  alert_listeners_(packet);
+    void MitsubishiUART::process_packet(const ConnectRequestPacket &packet)
+    {
+      // Nothing to be done for these except forward them along from thermostat to heat pump.
+      // This method defined so that these packets are not "unhandled"
+      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+      route_packet_(packet);
+    }
+    void MitsubishiUART::process_packet(const ConnectResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      // Not sure if there's any needed content in this response, so assume we're connected.
+      hp_connected_ = true;
+      ESP_LOGI(TAG, "Heatpump connected.");
+    }
 
-  // Mode
+    void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet)
+    {
+      // Nothing to be done for these except forward them along from thermostat to heat pump.
+      // This method defined so that these packets are not "unhandled"
+      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+      route_packet_(packet);
+    }
+    void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      // Not sure if there's any needed content in this response, so assume we're connected.
+      // TODO: Is there more useful info in these?
+      hp_connected_ = true;
+      capabilities_cache_ = packet;
+      ESP_LOGI(TAG, "Received heat pump identification packet.");
+    }
 
-  const climate::ClimateMode old_mode = mode;
-  if (packet.get_power()) {
-    switch (packet.get_mode()) {
+    void MitsubishiUART::process_packet(const GetRequestPacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+
+      switch (packet.get_requested_command())
+      {
+      case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
+        this->handle_thermostat_state_download_request(packet);
+        break;
+      case GetCommand::THERMOSTAT_GET_AB:
+        this->handle_thermostat_ab_get_request(packet);
+        break;
+      default:
+        route_packet_(packet);
+      }
+    }
+
+    void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      alert_listeners_(packet);
+
+      // Mode
+
+      const climate::ClimateMode old_mode = mode;
+      if (packet.get_power())
+      {
+        switch (packet.get_mode())
+        {
+        case 0x01:
+        case 0x09: // i-see
+          mode = climate::CLIMATE_MODE_HEAT;
+          break;
+        case 0x02:
+        case 0x0A: // i-see
+          mode = climate::CLIMATE_MODE_DRY;
+          break;
+        case 0x03:
+        case 0x0B: // i-see
+          mode = climate::CLIMATE_MODE_COOL;
+          break;
+        case 0x07:
+          mode = climate::CLIMATE_MODE_FAN_ONLY;
+          break;
+        case 0x08:
+        // unsure when 0x21 or 0x23 would ever be sent, as they seem to be Kumo exclusive, but let's handle them anyways.
+        case 0x21:
+        case 0x23:
+          mode = climate::CLIMATE_MODE_HEAT_COOL;
+          break;
+        default:
+          mode = climate::CLIMATE_MODE_OFF;
+        }
+      }
+      else
+      {
+        mode = climate::CLIMATE_MODE_OFF;
+      }
+
+      publish_on_update_ |= (old_mode != mode);
+
+      // Temperature
+      const float old_target_temperature = target_temperature;
+      target_temperature = packet.get_target_temp();
+      publish_on_update_ |= (old_target_temperature != target_temperature);
+      if (mode <= MAX_RECALL_MODE_INDEX)
+      {
+        mode_recall_setpoints_[mode] = target_temperature;
+      }
+
+      switch (mode)
+      {
+      case climate::CLIMATE_MODE_COOL:
+      case climate::CLIMATE_MODE_DRY:
+        this->mhk_state_.cool_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT:
+        this->mhk_state_.heat_setpoint_ = target_temperature;
+        break;
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        this->mhk_state_.cool_setpoint_ = target_temperature + 2;
+        this->mhk_state_.heat_setpoint_ = target_temperature - 2;
+      default:
+        break;
+      }
+
+      // Fan
+      static bool fan_changed = false;
+      switch (packet.get_fan())
+      {
+      case 0x00:
+        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+        break;
       case 0x01:
-      case 0x09:  // i-see
-        mode = climate::CLIMATE_MODE_HEAT;
+        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_QUIET);
         break;
       case 0x02:
-      case 0x0A:  // i-see
-        mode = climate::CLIMATE_MODE_DRY;
+        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_LOW);
         break;
       case 0x03:
-      case 0x0B:  // i-see
-        mode = climate::CLIMATE_MODE_COOL;
+        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
         break;
-      case 0x07:
-        mode = climate::CLIMATE_MODE_FAN_ONLY;
+      case 0x05:
+        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_HIGH);
         break;
-      case 0x08:
-      // unsure when 0x21 or 0x23 would ever be sent, as they seem to be Kumo exclusive, but let's handle them anyways.
-      case 0x21:
-      case 0x23:
-        mode = climate::CLIMATE_MODE_HEAT_COOL;
+      case 0x06:
+        fan_changed = set_custom_fan_mode_(FAN_MODE_VERYHIGH);
         break;
-      default:
-        mode = climate::CLIMATE_MODE_OFF;
+      }
+
+      publish_on_update_ |= fan_changed;
     }
-  } else {
-    mode = climate::CLIMATE_MODE_OFF;
-  }
 
-  publish_on_update_ |= (old_mode != mode);
+    void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      alert_listeners_(packet);
+      // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
+      const float old_current_temperature = current_temperature;
+      current_temperature = packet.get_current_temp();
 
-  // Temperature
-  const float old_target_temperature = target_temperature;
-  target_temperature = packet.get_target_temp();
-  publish_on_update_ |= (old_target_temperature != target_temperature);
-  if (mode <= MAX_RECALL_MODE_INDEX) {
-    mode_recall_setpoints_[mode] = target_temperature;
-  }
+      publish_on_update_ |= (old_current_temperature != current_temperature);
+    }
 
-  switch (mode) {
-    case climate::CLIMATE_MODE_COOL:
-    case climate::CLIMATE_MODE_DRY:
-      this->mhk_state_.cool_setpoint_ = target_temperature;
-      break;
-    case climate::CLIMATE_MODE_HEAT:
-      this->mhk_state_.heat_setpoint_ = target_temperature;
-      break;
-    case climate::CLIMATE_MODE_HEAT_COOL:
-      this->mhk_state_.cool_setpoint_ = target_temperature + 2;
-      this->mhk_state_.heat_setpoint_ = target_temperature - 2;
-    default:
-      break;
-  }
+    void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      alert_listeners_(packet);
 
-  // Fan
-  static bool fan_changed = false;
-  switch (packet.get_fan()) {
-    case 0x00:
-      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_AUTO);
-      break;
-    case 0x01:
-      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_QUIET);
-      break;
-    case 0x02:
-      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_LOW);
-      break;
-    case 0x03:
-      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
-      break;
-    case 0x05:
-      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_HIGH);
-      break;
-    case 0x06:
-      fan_changed = set_custom_fan_mode_(FAN_MODE_VERYHIGH);
-      break;
-  }
+      const climate::ClimateAction old_action = action;
 
-  publish_on_update_ |= fan_changed;
-}
-
-void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  alert_listeners_(packet);
-  // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
-  const float old_current_temperature = current_temperature;
-  current_temperature = packet.get_current_temp();
-
-  publish_on_update_ |= (old_current_temperature != current_temperature);
-}
-
-void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  alert_listeners_(packet);
-
-  const climate::ClimateAction old_action = action;
-
-  // If mode is off, action is off
-  if (mode == climate::CLIMATE_MODE_OFF) {
-    action = climate::CLIMATE_ACTION_OFF;
-  }
-  // If mode is fan only, packet.getOperating() may be false, but the fan is running
-  else if (mode == climate::CLIMATE_MODE_FAN_ONLY) {
-    action = climate::CLIMATE_ACTION_FAN;
-  }
-  // If mode is anything other than off or fan, and the unit is operating, determine the action
-  else if (packet.get_operating()) {
-    switch (mode) {
-      case climate::CLIMATE_MODE_HEAT:
-        action = climate::CLIMATE_ACTION_HEATING;
-        break;
-      case climate::CLIMATE_MODE_COOL:
-        action = climate::CLIMATE_ACTION_COOLING;
-        break;
-      case climate::CLIMATE_MODE_DRY:
-        action = climate::CLIMATE_ACTION_DRYING;
-        break;
-      // TODO: This only works if we get an update while the temps are in this configuration
-      // Surely there's some info from the heat pump about which of these modes it's in?
-      case climate::CLIMATE_MODE_HEAT_COOL:
-        if (current_temperature > target_temperature) {
-          action = climate::CLIMATE_ACTION_COOLING;
-        } else if (current_temperature < target_temperature) {
+      // If mode is off, action is off
+      if (mode == climate::CLIMATE_MODE_OFF)
+      {
+        action = climate::CLIMATE_ACTION_OFF;
+      }
+      // If mode is fan only, packet.getOperating() may be false, but the fan is running
+      else if (mode == climate::CLIMATE_MODE_FAN_ONLY)
+      {
+        action = climate::CLIMATE_ACTION_FAN;
+      }
+      // If mode is anything other than off or fan, and the unit is operating, determine the action
+      else if (packet.get_operating())
+      {
+        switch (mode)
+        {
+        case climate::CLIMATE_MODE_HEAT:
           action = climate::CLIMATE_ACTION_HEATING;
+          break;
+        case climate::CLIMATE_MODE_COOL:
+          action = climate::CLIMATE_ACTION_COOLING;
+          break;
+        case climate::CLIMATE_MODE_DRY:
+          action = climate::CLIMATE_ACTION_DRYING;
+          break;
+        // TODO: This only works if we get an update while the temps are in this configuration
+        // Surely there's some info from the heat pump about which of these modes it's in?
+        case climate::CLIMATE_MODE_HEAT_COOL:
+          if (current_temperature > target_temperature)
+          {
+            action = climate::CLIMATE_ACTION_COOLING;
+          }
+          else if (current_temperature < target_temperature)
+          {
+            action = climate::CLIMATE_ACTION_HEATING;
+          }
+          // When the heat pump *changes* to a new action, these temperature comparisons should be accurate.
+          // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
+          // If the unit overshoots, this still doesn't work.
+          break;
+        default:
+          ESP_LOGW(TAG, "Unhandled mode %i.", mode);
+          break;
         }
-        // When the heat pump *changes* to a new action, these temperature comparisons should be accurate.
-        // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
-        // If the unit overshoots, this still doesn't work.
-        break;
-      default:
-        ESP_LOGW(TAG, "Unhandled mode %i.", mode);
-        break;
+      }
+      // If we're not operating (but not off or in fan mode), we're idle
+      // Should be relatively safe to fall through any unknown modes into showing IDLE
+      else
+      {
+        action = climate::CLIMATE_ACTION_IDLE;
+      }
+
+      publish_on_update_ |= (old_action != action);
     }
-  }
-  // If we're not operating (but not off or in fan mode), we're idle
-  // Should be relatively safe to fall through any unknown modes into showing IDLE
-  else {
-    action = climate::CLIMATE_ACTION_IDLE;
-  }
+    void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      alert_listeners_(packet);
 
-  publish_on_update_ |= (old_action != action);
-}
-void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  alert_listeners_(packet);
+      run_state_received_ = true; // Set this since we received one
 
-  run_state_received_ = true;  // Set this since we received one
+      // TODO: Not sure what AutoMode does yet
+    }
 
-  // TODO: Not sure what AutoMode does yet
-}
+    void MitsubishiUART::process_packet(const ErrorStateGetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+      alert_listeners_(packet);
+    }
 
-void MitsubishiUART::process_packet(const ErrorStateGetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-  alert_listeners_(packet);
-}
+    void MitsubishiUART::process_packet(const Functions1GetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+    }
 
-void MitsubishiUART::process_packet(const Functions1GetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-}
+    void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      route_packet_(packet);
+    }
 
-void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
-}
+    void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet)
+    {
+      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
-  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+      // forward this packet as-is; we're just intercepting to log.
+      route_packet_(packet);
+      alert_listeners_(packet);
+    }
 
-  // forward this packet as-is; we're just intercepting to log.
-  route_packet_(packet);
-  alert_listeners_(packet);
-}
+    void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet)
+    {
+      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet) {
-  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+      // Only send this temperature packet to the heatpump if Thermostat is the selected source,
+      // or we're in passive mode (since in passive mode we're not generating any packets to
+      // set the temperature) otherwise just respond to the thermostat to keep it happy.
+      if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT)
+      {
+        route_packet_(packet);
+      }
+      else
+      {
+        ts_bridge_->send_packet(SetResponsePacket());
+      }
+      alert_listeners_(packet);
 
-  // Only send this temperature packet to the heatpump if Thermostat is the selected source,
-  // or we're in passive mode (since in passive mode we're not generating any packets to
-  // set the temperature) otherwise just respond to the thermostat to keep it happy.
-  if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT || !active_mode_) {
-    route_packet_(packet);
-  } else {
-    ts_bridge_->send_packet(SetResponsePacket());
-  }
-  alert_listeners_(packet);
+      float t = packet.get_remote_temperature();
+      temperature_source_report(TEMPERATURE_SOURCE_THERMOSTAT, t);
+    }
 
-  float t = packet.get_remote_temperature();
-  temperature_source_report(TEMPERATURE_SOURCE_THERMOSTAT, t);
-}
+    void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+        route_packet_(packet);
+        return;
+      }
 
-    route_packet_(packet);
-    return;
-  }
+      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+      alert_listeners_(packet);
 
-  alert_listeners_(packet);
+      ts_bridge_->send_packet(SetResponsePacket());
+    }
 
-  ts_bridge_->send_packet(SetResponsePacket());
-}
+    void MitsubishiUART::process_packet(const ThermostatHelloPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const ThermostatHelloPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+        route_packet_(packet);
+        return;
+      }
 
-    route_packet_(packet);
-    return;
-  }
+      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+      ts_bridge_->send_packet(SetResponsePacket());
+    }
 
-  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
-  ts_bridge_->send_packet(SetResponsePacket());
-}
+    void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+        route_packet_(packet);
+        return;
+      }
 
-    route_packet_(packet);
-    return;
-  }
+      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+      if (packet.get_flags() & 0x08)
+        this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
+      if (packet.get_flags() & 0x10)
+        this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
 
-  if (packet.get_flags() & 0x08)
-    this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
-  if (packet.get_flags() & 0x10)
-    this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
+      ts_bridge_->send_packet(SetResponsePacket());
+    }
 
-  ts_bridge_->send_packet(SetResponsePacket());
-}
+    void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+        route_packet_(packet);
+        return;
+      }
 
-    route_packet_(packet);
-    return;
-  }
+      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+      ts_bridge_->send_packet(SetResponsePacket());
+    }
 
-  ts_bridge_->send_packet(SetResponsePacket());
-}
+    void MitsubishiUART::process_packet(const SetResponsePacket &packet)
+    {
+      ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
+               packet.get_result_code());
+      route_packet_(packet);
+    }
 
-void MitsubishiUART::process_packet(const SetResponsePacket &packet) {
-  ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
-           packet.get_result_code());
-  route_packet_(packet);
-}
+    // Process incoming data requests from an MHK probing for/running in enhanced mode
+    void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        route_packet_(packet);
+        return;
+      }
 
-// Process incoming data requests from an MHK probing for/running in enhanced mode
-void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    route_packet_(packet);
-    return;
-  }
+      auto response = ThermostatStateDownloadResponsePacket();
 
-  auto response = ThermostatStateDownloadResponsePacket();
-
-  response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
-  response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
-  response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
+      response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
+      response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
+      response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
 
 #ifdef USE_TIME
-  if (this->time_source_ != nullptr) {
-    response.set_timestamp(this->time_source_->now());
-  } else {
-    ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-    response.set_timestamp(ESPTime::from_epoch_utc(1704067200));  // 2024-01-01 00:00:00Z
-  }
+      if (this->time_source_ != nullptr)
+      {
+        response.set_timestamp(this->time_source_->now());
+      }
+      else
+      {
+        ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
+        response.set_timestamp(ESPTime::from_epoch_utc(1704067200)); // 2024-01-01 00:00:00Z
+      }
 #else
-  ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-  response.set_timestamp(ESPTime::from_epoch_utc(1704067200));  // 2024-01-01 00:00:00Z
+      ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
+      response.set_timestamp(ESPTime::from_epoch_utc(1704067200)); // 2024-01-01 00:00:00Z
 #endif
 
-  ts_bridge_->send_packet(response);
-}
+      ts_bridge_->send_packet(response);
+    }
 
-void MitsubishiUART::handle_thermostat_ab_get_request(const GetRequestPacket &packet) {
-  if (!enhanced_mhk_support_) {
-    route_packet_(packet);
-    return;
-  }
+    void MitsubishiUART::handle_thermostat_ab_get_request(const GetRequestPacket &packet)
+    {
+      if (!enhanced_mhk_support_)
+      {
+        route_packet_(packet);
+        return;
+      }
 
-  auto response = ThermostatABGetResponsePacket();
+      auto response = ThermostatABGetResponsePacket();
 
-  ts_bridge_->send_packet(response);
-}
+      ts_bridge_->send_packet(response);
+    }
 
-}  // namespace mitsubishi_itp
-}  // namespace esphome
+  } // namespace mitsubishi_itp
+} // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -1,434 +1,377 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome
-{
-  namespace mitsubishi_itp
-  {
+namespace esphome {
+namespace mitsubishi_itp {
 
-    void MitsubishiUART::route_packet_(const Packet &packet)
-    {
-      // If the packet is associated with the thermostat and just came from the thermostat, send it to the heatpump
-      // If it came from the heatpump, send it back to the thermostat
-      if (packet.get_controller_association() == ControllerAssociation::THERMOSTAT)
-      {
-        if (packet.get_source_bridge() == SourceBridge::THERMOSTAT)
-        {
-          hp_bridge_.send_packet(packet);
-        }
-        else if (packet.get_source_bridge() == SourceBridge::HEATPUMP)
-        {
-          ts_bridge_->send_packet(packet);
-        }
-      }
+void MitsubishiUART::route_packet_(const Packet &packet) {
+  // If the packet is associated with the thermostat and just came from the thermostat, send it to the heatpump
+  // If it came from the heatpump, send it back to the thermostat
+  if (packet.get_controller_association() == ControllerAssociation::THERMOSTAT) {
+    if (packet.get_source_bridge() == SourceBridge::THERMOSTAT) {
+      hp_bridge_.send_packet(packet);
+    } else if (packet.get_source_bridge() == SourceBridge::HEATPUMP) {
+      ts_bridge_->send_packet(packet);
     }
+  }
+}
 
-    // Packet Handlers
-    void MitsubishiUART::process_packet(const Packet &packet)
-    {
-      ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
-      ESP_LOGD(TAG, "%s", packet.to_string().c_str());
+// Packet Handlers
+void MitsubishiUART::process_packet(const Packet &packet) {
+  ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
+  ESP_LOGD(TAG, "%s", packet.to_string().c_str());
+  route_packet_(packet);
+}
+
+void MitsubishiUART::process_packet(const ConnectRequestPacket &packet) {
+  // Nothing to be done for these except forward them along from thermostat to heat pump.
+  // This method defined so that these packets are not "unhandled"
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  route_packet_(packet);
+}
+void MitsubishiUART::process_packet(const ConnectResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  // Not sure if there's any needed content in this response, so assume we're connected.
+  hp_connected_ = true;
+  ESP_LOGI(TAG, "Heatpump connected.");
+}
+
+void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet) {
+  // Nothing to be done for these except forward them along from thermostat to heat pump.
+  // This method defined so that these packets are not "unhandled"
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  route_packet_(packet);
+}
+void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  // Not sure if there's any needed content in this response, so assume we're connected.
+  // TODO: Is there more useful info in these?
+  hp_connected_ = true;
+  capabilities_cache_ = packet;
+  ESP_LOGI(TAG, "Received heat pump identification packet.");
+}
+
+void MitsubishiUART::process_packet(const GetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+
+  switch (packet.get_requested_command()) {
+    case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
+      this->handle_thermostat_state_download_request(packet);
+      break;
+    case GetCommand::THERMOSTAT_GET_AB:
+      this->handle_thermostat_ab_get_request(packet);
+      break;
+    default:
       route_packet_(packet);
-    }
+  }
+}
 
-    void MitsubishiUART::process_packet(const ConnectRequestPacket &packet)
-    {
-      // Nothing to be done for these except forward them along from thermostat to heat pump.
-      // This method defined so that these packets are not "unhandled"
-      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-      route_packet_(packet);
-    }
-    void MitsubishiUART::process_packet(const ConnectResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      // Not sure if there's any needed content in this response, so assume we're connected.
-      hp_connected_ = true;
-      ESP_LOGI(TAG, "Heatpump connected.");
-    }
+void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  alert_listeners_(packet);
 
-    void MitsubishiUART::process_packet(const CapabilitiesRequestPacket &packet)
-    {
-      // Nothing to be done for these except forward them along from thermostat to heat pump.
-      // This method defined so that these packets are not "unhandled"
-      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-      route_packet_(packet);
-    }
-    void MitsubishiUART::process_packet(const CapabilitiesResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      // Not sure if there's any needed content in this response, so assume we're connected.
-      // TODO: Is there more useful info in these?
-      hp_connected_ = true;
-      capabilities_cache_ = packet;
-      ESP_LOGI(TAG, "Received heat pump identification packet.");
-    }
+  // Mode
 
-    void MitsubishiUART::process_packet(const GetRequestPacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-
-      switch (packet.get_requested_command())
-      {
-      case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
-        this->handle_thermostat_state_download_request(packet);
-        break;
-      case GetCommand::THERMOSTAT_GET_AB:
-        this->handle_thermostat_ab_get_request(packet);
-        break;
-      default:
-        route_packet_(packet);
-      }
-    }
-
-    void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      alert_listeners_(packet);
-
-      // Mode
-
-      const climate::ClimateMode old_mode = mode;
-      if (packet.get_power())
-      {
-        switch (packet.get_mode())
-        {
-        case 0x01:
-        case 0x09: // i-see
-          mode = climate::CLIMATE_MODE_HEAT;
-          break;
-        case 0x02:
-        case 0x0A: // i-see
-          mode = climate::CLIMATE_MODE_DRY;
-          break;
-        case 0x03:
-        case 0x0B: // i-see
-          mode = climate::CLIMATE_MODE_COOL;
-          break;
-        case 0x07:
-          mode = climate::CLIMATE_MODE_FAN_ONLY;
-          break;
-        case 0x08:
-        // unsure when 0x21 or 0x23 would ever be sent, as they seem to be Kumo exclusive, but let's handle them anyways.
-        case 0x21:
-        case 0x23:
-          mode = climate::CLIMATE_MODE_HEAT_COOL;
-          break;
-        default:
-          mode = climate::CLIMATE_MODE_OFF;
-        }
-      }
-      else
-      {
-        mode = climate::CLIMATE_MODE_OFF;
-      }
-
-      publish_on_update_ |= (old_mode != mode);
-
-      // Temperature
-      const float old_target_temperature = target_temperature;
-      target_temperature = packet.get_target_temp();
-      publish_on_update_ |= (old_target_temperature != target_temperature);
-      if (mode <= MAX_RECALL_MODE_INDEX)
-      {
-        mode_recall_setpoints_[mode] = target_temperature;
-      }
-
-      switch (mode)
-      {
-      case climate::CLIMATE_MODE_COOL:
-      case climate::CLIMATE_MODE_DRY:
-        this->mhk_state_.cool_setpoint_ = target_temperature;
-        break;
-      case climate::CLIMATE_MODE_HEAT:
-        this->mhk_state_.heat_setpoint_ = target_temperature;
-        break;
-      case climate::CLIMATE_MODE_HEAT_COOL:
-        this->mhk_state_.cool_setpoint_ = target_temperature + 2;
-        this->mhk_state_.heat_setpoint_ = target_temperature - 2;
-      default:
-        break;
-      }
-
-      // Fan
-      static bool fan_changed = false;
-      switch (packet.get_fan())
-      {
-      case 0x00:
-        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_AUTO);
-        break;
+  const climate::ClimateMode old_mode = mode;
+  if (packet.get_power()) {
+    switch (packet.get_mode()) {
       case 0x01:
-        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+      case 0x09:  // i-see
+        mode = climate::CLIMATE_MODE_HEAT;
         break;
       case 0x02:
-        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_LOW);
+      case 0x0A:  // i-see
+        mode = climate::CLIMATE_MODE_DRY;
         break;
       case 0x03:
-        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+      case 0x0B:  // i-see
+        mode = climate::CLIMATE_MODE_COOL;
         break;
-      case 0x05:
-        fan_changed = set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+      case 0x07:
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
         break;
-      case 0x06:
-        fan_changed = set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+      case 0x08:
+      // unsure when 0x21 or 0x23 would ever be sent, as they seem to be Kumo exclusive, but let's handle them anyways.
+      case 0x21:
+      case 0x23:
+        mode = climate::CLIMATE_MODE_HEAT_COOL;
         break;
-      }
-
-      publish_on_update_ |= fan_changed;
+      default:
+        mode = climate::CLIMATE_MODE_OFF;
     }
+  } else {
+    mode = climate::CLIMATE_MODE_OFF;
+  }
 
-    void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      alert_listeners_(packet);
-      // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
-      const float old_current_temperature = current_temperature;
-      current_temperature = packet.get_current_temp();
+  publish_on_update_ |= (old_mode != mode);
 
-      publish_on_update_ |= (old_current_temperature != current_temperature);
-    }
+  // Temperature
+  const float old_target_temperature = target_temperature;
+  target_temperature = packet.get_target_temp();
+  publish_on_update_ |= (old_target_temperature != target_temperature);
+  if (mode <= MAX_RECALL_MODE_INDEX) {
+    mode_recall_setpoints_[mode] = target_temperature;
+  }
 
-    void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      alert_listeners_(packet);
+  switch (mode) {
+    case climate::CLIMATE_MODE_COOL:
+    case climate::CLIMATE_MODE_DRY:
+      this->mhk_state_.cool_setpoint_ = target_temperature;
+      break;
+    case climate::CLIMATE_MODE_HEAT:
+      this->mhk_state_.heat_setpoint_ = target_temperature;
+      break;
+    case climate::CLIMATE_MODE_HEAT_COOL:
+      this->mhk_state_.cool_setpoint_ = target_temperature + 2;
+      this->mhk_state_.heat_setpoint_ = target_temperature - 2;
+    default:
+      break;
+  }
 
-      const climate::ClimateAction old_action = action;
+  // Fan
+  static bool fan_changed = false;
+  switch (packet.get_fan()) {
+    case 0x00:
+      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_AUTO);
+      break;
+    case 0x01:
+      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+      break;
+    case 0x02:
+      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_LOW);
+      break;
+    case 0x03:
+      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
+      break;
+    case 0x05:
+      fan_changed = set_fan_mode_(climate::CLIMATE_FAN_HIGH);
+      break;
+    case 0x06:
+      fan_changed = set_custom_fan_mode_(FAN_MODE_VERYHIGH);
+      break;
+  }
 
-      // If mode is off, action is off
-      if (mode == climate::CLIMATE_MODE_OFF)
-      {
-        action = climate::CLIMATE_ACTION_OFF;
-      }
-      // If mode is fan only, packet.getOperating() may be false, but the fan is running
-      else if (mode == climate::CLIMATE_MODE_FAN_ONLY)
-      {
-        action = climate::CLIMATE_ACTION_FAN;
-      }
-      // If mode is anything other than off or fan, and the unit is operating, determine the action
-      else if (packet.get_operating())
-      {
-        switch (mode)
-        {
-        case climate::CLIMATE_MODE_HEAT:
-          action = climate::CLIMATE_ACTION_HEATING;
-          break;
-        case climate::CLIMATE_MODE_COOL:
+  publish_on_update_ |= fan_changed;
+}
+
+void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  alert_listeners_(packet);
+  // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
+  const float old_current_temperature = current_temperature;
+  current_temperature = packet.get_current_temp();
+
+  publish_on_update_ |= (old_current_temperature != current_temperature);
+}
+
+void MitsubishiUART::process_packet(const StatusGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  alert_listeners_(packet);
+
+  const climate::ClimateAction old_action = action;
+
+  // If mode is off, action is off
+  if (mode == climate::CLIMATE_MODE_OFF) {
+    action = climate::CLIMATE_ACTION_OFF;
+  }
+  // If mode is fan only, packet.getOperating() may be false, but the fan is running
+  else if (mode == climate::CLIMATE_MODE_FAN_ONLY) {
+    action = climate::CLIMATE_ACTION_FAN;
+  }
+  // If mode is anything other than off or fan, and the unit is operating, determine the action
+  else if (packet.get_operating()) {
+    switch (mode) {
+      case climate::CLIMATE_MODE_HEAT:
+        action = climate::CLIMATE_ACTION_HEATING;
+        break;
+      case climate::CLIMATE_MODE_COOL:
+        action = climate::CLIMATE_ACTION_COOLING;
+        break;
+      case climate::CLIMATE_MODE_DRY:
+        action = climate::CLIMATE_ACTION_DRYING;
+        break;
+      // TODO: This only works if we get an update while the temps are in this configuration
+      // Surely there's some info from the heat pump about which of these modes it's in?
+      case climate::CLIMATE_MODE_HEAT_COOL:
+        if (current_temperature > target_temperature) {
           action = climate::CLIMATE_ACTION_COOLING;
-          break;
-        case climate::CLIMATE_MODE_DRY:
-          action = climate::CLIMATE_ACTION_DRYING;
-          break;
-        // TODO: This only works if we get an update while the temps are in this configuration
-        // Surely there's some info from the heat pump about which of these modes it's in?
-        case climate::CLIMATE_MODE_HEAT_COOL:
-          if (current_temperature > target_temperature)
-          {
-            action = climate::CLIMATE_ACTION_COOLING;
-          }
-          else if (current_temperature < target_temperature)
-          {
-            action = climate::CLIMATE_ACTION_HEATING;
-          }
-          // When the heat pump *changes* to a new action, these temperature comparisons should be accurate.
-          // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
-          // If the unit overshoots, this still doesn't work.
-          break;
-        default:
-          ESP_LOGW(TAG, "Unhandled mode %i.", mode);
-          break;
+        } else if (current_temperature < target_temperature) {
+          action = climate::CLIMATE_ACTION_HEATING;
         }
-      }
-      // If we're not operating (but not off or in fan mode), we're idle
-      // Should be relatively safe to fall through any unknown modes into showing IDLE
-      else
-      {
-        action = climate::CLIMATE_ACTION_IDLE;
-      }
-
-      publish_on_update_ |= (old_action != action);
+        // When the heat pump *changes* to a new action, these temperature comparisons should be accurate.
+        // If the mode hasn't changed, but the temps are equal, we can assume the same action and make no change.
+        // If the unit overshoots, this still doesn't work.
+        break;
+      default:
+        ESP_LOGW(TAG, "Unhandled mode %i.", mode);
+        break;
     }
-    void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      alert_listeners_(packet);
+  }
+  // If we're not operating (but not off or in fan mode), we're idle
+  // Should be relatively safe to fall through any unknown modes into showing IDLE
+  else {
+    action = climate::CLIMATE_ACTION_IDLE;
+  }
 
-      run_state_received_ = true; // Set this since we received one
+  publish_on_update_ |= (old_action != action);
+}
+void MitsubishiUART::process_packet(const RunStateGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  alert_listeners_(packet);
 
-      // TODO: Not sure what AutoMode does yet
-    }
+  run_state_received_ = true;  // Set this since we received one
 
-    void MitsubishiUART::process_packet(const ErrorStateGetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-      alert_listeners_(packet);
-    }
+  // TODO: Not sure what AutoMode does yet
+}
 
-    void MitsubishiUART::process_packet(const Functions1GetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-    }
+void MitsubishiUART::process_packet(const ErrorStateGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+  alert_listeners_(packet);
+}
 
-    void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-      route_packet_(packet);
-    }
+void MitsubishiUART::process_packet(const Functions1GetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+}
 
-    void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet)
-    {
-      ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  route_packet_(packet);
+}
 
-      // forward this packet as-is; we're just intercepting to log.
-      route_packet_(packet);
-      alert_listeners_(packet);
-    }
+void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-    void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet)
-    {
-      ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  // forward this packet as-is; we're just intercepting to log.
+  route_packet_(packet);
+  alert_listeners_(packet);
+}
 
-      // Only send this temperature packet to the heatpump if Thermostat is the selected source,
-      // or we're in passive mode (since in passive mode we're not generating any packets to
-      // set the temperature) otherwise just respond to the thermostat to keep it happy.
-      if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT)
-      {
-        route_packet_(packet);
-      }
-      else
-      {
-        ts_bridge_->send_packet(SetResponsePacket());
-      }
-      alert_listeners_(packet);
+void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-      float t = packet.get_remote_temperature();
-      temperature_source_report(TEMPERATURE_SOURCE_THERMOSTAT, t);
-    }
+  // Only send this temperature packet to the heatpump if Thermostat is the selected source,
+  // or we're in passive mode (since in passive mode we're not generating any packets to
+  // set the temperature) otherwise just respond to the thermostat to keep it happy.
+  if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT) {
+    route_packet_(packet);
+  } else {
+    ts_bridge_->send_packet(SetResponsePacket());
+  }
+  alert_listeners_(packet);
 
-    void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  float t = packet.get_remote_temperature();
+  temperature_source_report(TEMPERATURE_SOURCE_THERMOSTAT, t);
+}
 
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::process_packet(const ThermostatSensorStatusPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+    route_packet_(packet);
+    return;
+  }
 
-      alert_listeners_(packet);
+  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-      ts_bridge_->send_packet(SetResponsePacket());
-    }
+  alert_listeners_(packet);
 
-    void MitsubishiUART::process_packet(const ThermostatHelloPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  ts_bridge_->send_packet(SetResponsePacket());
+}
 
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::process_packet(const ThermostatHelloPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
-      ts_bridge_->send_packet(SetResponsePacket());
-    }
+    route_packet_(packet);
+    return;
+  }
 
-    void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+  ts_bridge_->send_packet(SetResponsePacket());
+}
 
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+    route_packet_(packet);
+    return;
+  }
 
-      if (packet.get_flags() & 0x08)
-        this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
-      if (packet.get_flags() & 0x10)
-        this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
+  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-      ts_bridge_->send_packet(SetResponsePacket());
-    }
+  if (packet.get_flags() & 0x08)
+    this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
+  if (packet.get_flags() & 0x10)
+    this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
 
-    void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+  ts_bridge_->send_packet(SetResponsePacket());
+}
 
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
 
-      ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
+    route_packet_(packet);
+    return;
+  }
 
-      ts_bridge_->send_packet(SetResponsePacket());
-    }
+  ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-    void MitsubishiUART::process_packet(const SetResponsePacket &packet)
-    {
-      ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
-               packet.get_result_code());
-      route_packet_(packet);
-    }
+  ts_bridge_->send_packet(SetResponsePacket());
+}
 
-    // Process incoming data requests from an MHK probing for/running in enhanced mode
-    void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::process_packet(const SetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
+           packet.get_result_code());
+  route_packet_(packet);
+}
 
-      auto response = ThermostatStateDownloadResponsePacket();
+// Process incoming data requests from an MHK probing for/running in enhanced mode
+void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    route_packet_(packet);
+    return;
+  }
 
-      response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
-      response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
-      response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
+  auto response = ThermostatStateDownloadResponsePacket();
+
+  response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
+  response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
+  response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
 
 #ifdef USE_TIME
-      if (this->time_source_ != nullptr)
-      {
-        response.set_timestamp(this->time_source_->now());
-      }
-      else
-      {
-        ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-        response.set_timestamp(ESPTime::from_epoch_utc(1704067200)); // 2024-01-01 00:00:00Z
-      }
+  if (this->time_source_ != nullptr) {
+    response.set_timestamp(this->time_source_->now());
+  } else {
+    ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
+    response.set_timestamp(ESPTime::from_epoch_utc(1704067200));  // 2024-01-01 00:00:00Z
+  }
 #else
-      ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-      response.set_timestamp(ESPTime::from_epoch_utc(1704067200)); // 2024-01-01 00:00:00Z
+  ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
+  response.set_timestamp(ESPTime::from_epoch_utc(1704067200));  // 2024-01-01 00:00:00Z
 #endif
 
-      ts_bridge_->send_packet(response);
-    }
+  ts_bridge_->send_packet(response);
+}
 
-    void MitsubishiUART::handle_thermostat_ab_get_request(const GetRequestPacket &packet)
-    {
-      if (!enhanced_mhk_support_)
-      {
-        route_packet_(packet);
-        return;
-      }
+void MitsubishiUART::handle_thermostat_ab_get_request(const GetRequestPacket &packet) {
+  if (!enhanced_mhk_support_) {
+    route_packet_(packet);
+    return;
+  }
 
-      auto response = ThermostatABGetResponsePacket();
+  auto response = ThermostatABGetResponsePacket();
 
-      ts_bridge_->send_packet(response);
-    }
+  ts_bridge_->send_packet(response);
+}
 
-  } // namespace mitsubishi_itp
-} // namespace esphome
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -1,308 +1,364 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome {
-namespace mitsubishi_itp {
+namespace esphome
+{
+  namespace mitsubishi_itp
+  {
 
-////
-// MitsubishiUART
-////
+    ////
+    // MitsubishiUART
+    ////
 
-MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
-    : hp_uart_{*hp_uart_comp}, hp_bridge_{HeatpumpBridge(hp_uart_comp, this)} {
-  /**
-   * Climate pushes all its data to Home Assistant immediately when the API connects, this causes
-   * the default 0 to be sent as temperatures, but since this is a valid value (0 deg C), it
-   * can cause confusion and mess with graphs when looking at the state in HA.  Setting this to
-   * NAN gets HA to treat this value as "unavailable" until we have a real value to publish.
-   */
-  target_temperature = NAN;
-  current_temperature = NAN;
-}
+    MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
+        : hp_uart_{*hp_uart_comp}, hp_bridge_{HeatpumpBridge(hp_uart_comp, this)}
+    {
+      /**
+       * Climate pushes all its data to Home Assistant immediately when the API connects, this causes
+       * the default 0 to be sent as temperatures, but since this is a valid value (0 deg C), it
+       * can cause confusion and mess with graphs when looking at the state in HA.  Setting this to
+       * NAN gets HA to treat this value as "unavailable" until we have a real value to publish.
+       */
+      target_temperature = NAN;
+      current_temperature = NAN;
+    }
 
-// Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
-// Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
-void MitsubishiUART::setup() {
-  for (auto *listener : listeners_) {
-    listener->setup(bool(ts_uart_));
-  }
-  // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
-  // is an easy way to prevent wierd conflicts if e.g. select options change.
-  preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
-                                                                      fnv1_hash(App.get_compilation_time()));
-  restore_preferences_();
-}
+    // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
+    // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+    void MitsubishiUART::setup()
+    {
+      for (auto *listener : listeners_)
+      {
+        listener->setup(bool(ts_uart_));
+      }
+      // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
+      // is an easy way to prevent wierd conflicts if e.g. select options change.
+      preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
+                                                                          fnv1_hash(App.get_compilation_time()));
+      restore_preferences_();
+    }
 
-void MitsubishiUART::restore_preferences_() {
-  MITPPreferences prefs;
-  if (preferences_.load(&prefs)) {
-    for (auto i = 0; i < MAX_RECALL_MODE_INDEX; i++) {
-      if (prefs.modeRecallSetpoints[i] > 0) {
-        // If any setpoints are set, assume valid preferences and load all of them
-        mode_recall_setpoints_ = prefs.modeRecallSetpoints;
-        ESP_LOGCONFIG(TAG, "Loaded mode recall setpoints.");
-        break;
+    void MitsubishiUART::restore_preferences_()
+    {
+      MITPPreferences prefs;
+      if (preferences_.load(&prefs))
+      {
+        for (auto i = 0; i < MAX_RECALL_MODE_INDEX; i++)
+        {
+          if (prefs.modeRecallSetpoints[i] > 0)
+          {
+            // If any setpoints are set, assume valid preferences and load all of them
+            mode_recall_setpoints_ = prefs.modeRecallSetpoints;
+            ESP_LOGCONFIG(TAG, "Loaded mode recall setpoints.");
+            break;
+          }
+        }
       }
     }
-  }
-}
 
-void MitsubishiUART::save_preferences_() {
-  MITPPreferences prefs{};
-  prefs.modeRecallSetpoints = mode_recall_setpoints_;
-  preferences_.save(&prefs);
-}
-
-void MitsubishiUART::send_if_active_(const Packet &packet) {
-  if (active_mode_)
-    hp_bridge_.send_packet(packet);
-}
-
-#define IFACTIVE(dothis) \
-  if (active_mode_) { \
-    dothis \
-  }
-#define IFNOTACTIVE(dothis) \
-  if (!active_mode_) { \
-    dothis \
-  }
-
-/* Used for receiving and acting on incoming packets as soon as they're available.
-  Because packet processing happens as part of the receiving process, packet processing
-  should not block for very long (e.g. no publishing inside the packet processing)
-*/
-void MitsubishiUART::loop() {
-  // Loop bridge to handle sending and receiving packets
-  hp_bridge_.loop();
-  if (ts_bridge_)
-    ts_bridge_->loop();
-
-  if ((millis() - last_received_temperature_) > TEMPERATURE_SOURCE_TIMEOUT_MS) {
-    if (current_temperature_source_.empty() || current_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL) {
-      ESP_LOGD(TAG, "Reminding heat pump to use internal temperature sensor");
-      // Check to make sure a temperature source is set-- if not, set to internal for sanity reasons
-      IFACTIVE(this->select_temperature_source(TEMPERATURE_SOURCE_INTERNAL);)
-      last_received_temperature_ = millis();  // Count this as "receiving" the internal temperature
-    } else if (!temperature_source_timeout_) {
-      // If it's been too long since we received a temperature update (and we're not set to Internal)
-      ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
-               current_temperature_source_.c_str(), (unsigned long) TEMPERATURE_SOURCE_TIMEOUT_MS);
-      // Let listeners know we've changed to the Internal temperature source (but do not change
-      // currentTemperatureSource)
-      for (auto *listener : listeners_) {
-        listener->temperature_source_change(TEMPERATURE_SOURCE_INTERNAL);
-      }
-      temperature_source_timeout_ = true;
-      // Send a packet to the heat pump to tell it to switch to internal temperature sensing
-      IFACTIVE(hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());)
+    void MitsubishiUART::save_preferences_()
+    {
+      MITPPreferences prefs{};
+      prefs.modeRecallSetpoints = mode_recall_setpoints_;
+      preferences_.save(&prefs);
     }
-  }
-}
 
-void MitsubishiUART::dump_config() {
-  if (capabilities_cache_.has_value()) {
-    ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
-  }
+    /* Used for receiving and acting on incoming packets as soon as they're available.
+      Because packet processing happens as part of the receiving process, packet processing
+      should not block for very long (e.g. no publishing inside the packet processing)
+    */
+    void MitsubishiUART::loop()
+    {
+      // Loop bridge to handle sending and receiving packets
+      hp_bridge_.loop();
+      if (ts_bridge_)
+        ts_bridge_->loop();
 
-  if (enhanced_mhk_support_) {
-    ESP_LOGCONFIG(TAG, "MHK Enhanced Protocol Mode is ENABLED! This is currently *experimental* and things may break!");
-  }
-}
+      if ((millis() - last_received_temperature_) > TEMPERATURE_SOURCE_TIMEOUT_MS)
+      {
+        if (current_temperature_source_.empty() || current_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL)
+        {
+          ESP_LOGD(TAG, "Reminding heat pump to use internal temperature sensor");
+          // Check to make sure a temperature source is set-- if not, set to internal for sanity reasons
+          this->select_temperature_source(TEMPERATURE_SOURCE_INTERNAL);
+          last_received_temperature_ = millis(); // Count this as "receiving" the internal temperature
+        }
+        else if (!temperature_source_timeout_)
+        {
+          // If it's been too long since we received a temperature update (and we're not set to Internal)
+          ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
+                   current_temperature_source_.c_str(), (unsigned long)TEMPERATURE_SOURCE_TIMEOUT_MS);
+          // Let listeners know we've changed to the Internal temperature source (but do not change
+          // currentTemperatureSource)
+          for (auto *listener : listeners_)
+          {
+            listener->temperature_source_change(TEMPERATURE_SOURCE_INTERNAL);
+          }
+          temperature_source_timeout_ = true;
+          // Send a packet to the heat pump to tell it to switch to internal temperature sensing
+          hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
+        }
+      }
+    }
 
-// Set thermostat UART component
-void MitsubishiUART::set_thermostat_uart(uart::UARTComponent *uart) {
-  ESP_LOGCONFIG(TAG, "Thermostat uart was set.");
-  ts_uart_ = uart;
-  ts_bridge_ = make_unique<ThermostatBridge>(ts_uart_, static_cast<PacketProcessor *>(this));
-}
+    void MitsubishiUART::dump_config()
+    {
+      if (capabilities_cache_.has_value())
+      {
+        ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
+      }
 
-/* Called periodically as PollingComponent; used to send packets to connect or request updates.
+      if (enhanced_mhk_support_)
+      {
+        ESP_LOGCONFIG(TAG, "MHK Enhanced Protocol Mode is ENABLED! This is currently *experimental* and things may break!");
+      }
+    }
 
-Possible TODO: If we only publish during updates, since data is received during loop, updates will always
-be about `update_interval` late from their actual time.  Generally the update interval should be low enough
-(default is 5seconds) this won't pose a practical problem.
-*/
-void MitsubishiUART::update() {
-  // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
-  if (millis() < 5000) {
-    return;
-  }
+    // Set thermostat UART component
+    void MitsubishiUART::set_thermostat_uart(uart::UARTComponent *uart)
+    {
+      ESP_LOGCONFIG(TAG, "Thermostat uart was set.");
+      ts_uart_ = uart;
+      ts_bridge_ = make_unique<ThermostatBridge>(ts_uart_, static_cast<PacketProcessor *>(this));
+    }
 
-  // If we're not yet connected, send off a connection request (we'll check again next update)
-  if (!hp_connected_) {
-    IFACTIVE(hp_bridge_.send_packet(ConnectRequestPacket::instance());)
-    return;
-  }
+    /* Called periodically as PollingComponent; used to send packets to connect or request updates.
 
-  // Attempt to read capabilities on the next loop after connect.
-  // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper
-  // autoconf.
-  //       For now, just requesting it as part of our "init loops" is a good first step.
-  if (!this->capabilities_requested_) {
-    IFACTIVE(hp_bridge_.send_packet(CapabilitiesRequestPacket::instance()); this->capabilities_requested_ = true;)
-  }
+    Possible TODO: If we only publish during updates, since data is received during loop, updates will always
+    be about `update_interval` late from their actual time.  Generally the update interval should be low enough
+    (default is 5seconds) this won't pose a practical problem.
+    */
+    void MitsubishiUART::update()
+    {
+      // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
+      if (millis() < 5000)
+      {
+        return;
+      }
 
-  // Before requesting additional updates, publish any changes waiting from packets received
+      // If we're not yet connected, send off a connection request (we'll check again next update)
+      if (!hp_connected_)
+      {
+        hp_bridge_.send_packet(ConnectRequestPacket::instance());
+        return;
+      }
 
-  // Notify all listeners a publish is happening, they will decide if actual publish is needed.
-  for (auto *listener : listeners_) {
-    listener->publish();
-  }
+      // Attempt to read capabilities on the next loop after connect.
+      // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper
+      // autoconf.
+      //       For now, just requesting it as part of our "init loops" is a good first step.
+      if (!this->capabilities_requested_)
+      {
+        hp_bridge_.send_packet(CapabilitiesRequestPacket::instance());
+        this->capabilities_requested_ = true;
+      }
 
-  if (publish_on_update_) {
-    do_publish_();
+      // Before requesting additional updates, publish any changes waiting from packets received
 
-    publish_on_update_ = false;
-  }
+      // Notify all listeners a publish is happening, they will decide if actual publish is needed.
+      for (auto *listener : listeners_)
+      {
+        listener->publish();
+      }
 
-  IFACTIVE(
+      if (publish_on_update_)
+      {
+        do_publish_();
+
+        publish_on_update_ = false;
+      }
+
       // Request an update from the heatpump
       // TODO: This isn't a problem *yet*, but sending all these packets every loop might start to cause some issues
       // in
       //       certain configurations or setups. We may want to consider only asking for certain packets on a rarer
       //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
       hp_bridge_.send_packet(
-          GetRequestPacket::get_settings_instance());  // Needs to be done before status packet for mode logic to work
-      if (in_discovery_ || run_state_received_) { hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance()); }
+          GetRequestPacket::get_settings_instance()); // Needs to be done before status packet for mode logic to work
+      if (in_discovery_ || run_state_received_)
+      {
+        hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
+      }
 
       hp_bridge_.send_packet(GetRequestPacket::get_status_instance());
       hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
-      hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());)
+      hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());
 
-  if (in_discovery_) {
-    // After criteria met, exit discovery mode
-    // Currently this is either 5 updates or a successful RunState response.
-    if (discovery_updates_++ > 5 || run_state_received_) {
-      ESP_LOGD(TAG, "Discovery complete.");
-      in_discovery_ = false;
+      if (in_discovery_)
+      {
+        // After criteria met, exit discovery mode
+        // Currently this is either 5 updates or a successful RunState response.
+        if (discovery_updates_++ > 5 || run_state_received_)
+        {
+          ESP_LOGD(TAG, "Discovery complete.");
+          in_discovery_ = false;
 
-      if (!run_state_received_) {
-        ESP_LOGI(TAG, "RunState packets not supported.");
+          if (!run_state_received_)
+          {
+            ESP_LOGI(TAG, "RunState packets not supported.");
+          }
+        }
       }
     }
-  }
-}
 
-void MitsubishiUART::do_publish_() {
-  publish_state();
-  // We can safely do this on every publish as ESPPreferences collects changes and only writes if different
-  save_preferences_();
-}
-
-bool MitsubishiUART::select_temperature_source(const std::string &state) {
-  // TODO: Possibly check to see if state is available from the select options?  (Might be a bit redundant)
-
-  current_temperature_source_ = state;
-  // Reset the timeout for received temperature (without this, the menu dropdown will switch back to Internal
-  // temporarily)
-  last_received_temperature_ = millis();
-
-  // If we've switched to internal, let the HP know right away
-  if (TEMPERATURE_SOURCE_INTERNAL == state) {
-    IFACTIVE(hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());)
-  }
-
-  return true;
-}
-
-bool MitsubishiUART::select_vane_position(const std::string &state) {
-  IFNOTACTIVE(return false;)  // Skip this if we're not in active mode
-  SettingsSetRequestPacket::VaneByte position_byte = SettingsSetRequestPacket::VANE_AUTO;
-
-  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
-  // infrequently, this is probably a better solution than over-optimizing via maps or something
-
-  if (state == "Auto") {
-    position_byte = SettingsSetRequestPacket::VANE_AUTO;
-  } else if (state == "1") {
-    position_byte = SettingsSetRequestPacket::VANE_1;
-  } else if (state == "2") {
-    position_byte = SettingsSetRequestPacket::VANE_2;
-  } else if (state == "3") {
-    position_byte = SettingsSetRequestPacket::VANE_3;
-  } else if (state == "4") {
-    position_byte = SettingsSetRequestPacket::VANE_4;
-  } else if (state == "5") {
-    position_byte = SettingsSetRequestPacket::VANE_5;
-  } else if (state == "Swing") {
-    position_byte = SettingsSetRequestPacket::VANE_SWING;
-  } else {
-    ESP_LOGW(TAG, "Unknown vane position %s", state.c_str());
-    return false;
-  }
-
-  hp_bridge_.send_packet(SettingsSetRequestPacket().set_vane(position_byte));
-  return true;
-}
-
-bool MitsubishiUART::select_horizontal_vane_position(const std::string &state) {
-  IFNOTACTIVE(return false;)  // Skip this if we're not in active mode
-  SettingsSetRequestPacket::HorizontalVaneByte position_byte = SettingsSetRequestPacket::HV_CENTER;
-
-  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
-  // infrequently, this is probably a better solution than over-optimizing via maps or something
-
-  if (state == "Auto") {
-    position_byte = SettingsSetRequestPacket::HV_AUTO;
-  } else if (state == "<<") {
-    position_byte = SettingsSetRequestPacket::HV_LEFT_FULL;
-  } else if (state == "<") {
-    position_byte = SettingsSetRequestPacket::HV_LEFT;
-  } else if (state == "|") {
-    position_byte = SettingsSetRequestPacket::HV_CENTER;
-  } else if (state == ">") {
-    position_byte = SettingsSetRequestPacket::HV_RIGHT;
-  } else if (state == ">>") {
-    position_byte = SettingsSetRequestPacket::HV_RIGHT_FULL;
-  } else if (state == "<>") {
-    position_byte = SettingsSetRequestPacket::HV_SPLIT;
-  } else if (state == "Swing") {
-    position_byte = SettingsSetRequestPacket::HV_SWING;
-  } else {
-    ESP_LOGW(TAG, "Unknown horizontal vane position %s", state.c_str());
-    return false;
-  }
-
-  hp_bridge_.send_packet(SettingsSetRequestPacket().set_horizontal_vane(position_byte));
-  return true;
-}
-
-// Called by temperature_source sensors to report values.  Will only take action if the currentTemperatureSource
-// matches the incoming source.  Specifically this means that we are not storing any values
-// for sensors other than the current source, and selecting a different source won't have any
-// effect until that source reports a temperature.
-// TODO: ? Maybe store all temperatures (and report on them using internal sensors??) so that selecting a new
-// source takes effect immediately?  Only really needed if source sensors are configured with very slow update times.
-void MitsubishiUART::temperature_source_report(const std::string &temperature_source, const float &v) {
-  ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
-           current_temperature_source_.c_str());
-
-  // Only proceed if the incomming source matches our chosen source.
-  if (current_temperature_source_ == temperature_source) {
-    // Reset the timeout for received temperature
-    last_received_temperature_ = millis();
-    temperature_source_timeout_ = false;
-
-    // Tell the heat pump about the temperature asap, but don't worry about setting it locally, the next update() will
-    // get it
-    IFACTIVE(RemoteTemperatureSetRequestPacket pkt = RemoteTemperatureSetRequestPacket(); pkt.set_remote_temperature(v);
-             hp_bridge_.send_packet(pkt);)
-
-    // If we've changed the select to reflect a temporary reversion to a different source, change it back.
-    for (auto *listener : listeners_) {
-      listener->temperature_source_change(current_temperature_source_);
+    void MitsubishiUART::do_publish_()
+    {
+      publish_state();
+      // We can safely do this on every publish as ESPPreferences collects changes and only writes if different
+      save_preferences_();
     }
-  }
-}
 
-void MitsubishiUART::reset_filter_status() {
-  ESP_LOGI(TAG, "Received a request to reset the filter status.");
+    bool MitsubishiUART::select_temperature_source(const std::string &state)
+    {
+      // TODO: Possibly check to see if state is available from the select options?  (Might be a bit redundant)
 
-  IFNOTACTIVE(return;)
+      current_temperature_source_ = state;
+      // Reset the timeout for received temperature (without this, the menu dropdown will switch back to Internal
+      // temporarily)
+      last_received_temperature_ = millis();
 
-  SetRunStatePacket pkt = SetRunStatePacket();
-  pkt.set_filter_reset(true);
-  hp_bridge_.send_packet(pkt);
-}
+      // If we've switched to internal, let the HP know right away
+      if (TEMPERATURE_SOURCE_INTERNAL == state)
+      {
+        hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
+      }
 
-}  // namespace mitsubishi_itp
-}  // namespace esphome
+      return true;
+    }
+
+    bool MitsubishiUART::select_vane_position(const std::string &state)
+    {
+      SettingsSetRequestPacket::VaneByte position_byte = SettingsSetRequestPacket::VANE_AUTO;
+
+      // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+      // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+      if (state == "Auto")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_AUTO;
+      }
+      else if (state == "1")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_1;
+      }
+      else if (state == "2")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_2;
+      }
+      else if (state == "3")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_3;
+      }
+      else if (state == "4")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_4;
+      }
+      else if (state == "5")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_5;
+      }
+      else if (state == "Swing")
+      {
+        position_byte = SettingsSetRequestPacket::VANE_SWING;
+      }
+      else
+      {
+        ESP_LOGW(TAG, "Unknown vane position %s", state.c_str());
+        return false;
+      }
+
+      hp_bridge_.send_packet(SettingsSetRequestPacket().set_vane(position_byte));
+      return true;
+    }
+
+    bool MitsubishiUART::select_horizontal_vane_position(const std::string &state)
+    {
+      SettingsSetRequestPacket::HorizontalVaneByte position_byte = SettingsSetRequestPacket::HV_CENTER;
+
+      // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+      // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+      if (state == "Auto")
+      {
+        position_byte = SettingsSetRequestPacket::HV_AUTO;
+      }
+      else if (state == "<<")
+      {
+        position_byte = SettingsSetRequestPacket::HV_LEFT_FULL;
+      }
+      else if (state == "<")
+      {
+        position_byte = SettingsSetRequestPacket::HV_LEFT;
+      }
+      else if (state == "|")
+      {
+        position_byte = SettingsSetRequestPacket::HV_CENTER;
+      }
+      else if (state == ">")
+      {
+        position_byte = SettingsSetRequestPacket::HV_RIGHT;
+      }
+      else if (state == ">>")
+      {
+        position_byte = SettingsSetRequestPacket::HV_RIGHT_FULL;
+      }
+      else if (state == "<>")
+      {
+        position_byte = SettingsSetRequestPacket::HV_SPLIT;
+      }
+      else if (state == "Swing")
+      {
+        position_byte = SettingsSetRequestPacket::HV_SWING;
+      }
+      else
+      {
+        ESP_LOGW(TAG, "Unknown horizontal vane position %s", state.c_str());
+        return false;
+      }
+
+      hp_bridge_.send_packet(SettingsSetRequestPacket().set_horizontal_vane(position_byte));
+      return true;
+    }
+
+    // Called by temperature_source sensors to report values.  Will only take action if the currentTemperatureSource
+    // matches the incoming source.  Specifically this means that we are not storing any values
+    // for sensors other than the current source, and selecting a different source won't have any
+    // effect until that source reports a temperature.
+    // TODO: ? Maybe store all temperatures (and report on them using internal sensors??) so that selecting a new
+    // source takes effect immediately?  Only really needed if source sensors are configured with very slow update times.
+    void MitsubishiUART::temperature_source_report(const std::string &temperature_source, const float &v)
+    {
+      ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
+               current_temperature_source_.c_str());
+
+      // Only proceed if the incomming source matches our chosen source.
+      if (current_temperature_source_ == temperature_source)
+      {
+        // Reset the timeout for received temperature
+        last_received_temperature_ = millis();
+        temperature_source_timeout_ = false;
+
+        // Tell the heat pump about the temperature asap, but don't worry about setting it locally, the next update() will
+        // get it
+        RemoteTemperatureSetRequestPacket pkt = RemoteTemperatureSetRequestPacket();
+        pkt.set_remote_temperature(v);
+        hp_bridge_.send_packet(pkt);
+
+        // If we've changed the select to reflect a temporary reversion to a different source, change it back.
+        for (auto *listener : listeners_)
+        {
+          listener->temperature_source_change(current_temperature_source_);
+        }
+      }
+    }
+
+    void MitsubishiUART::reset_filter_status()
+    {
+      ESP_LOGI(TAG, "Received a request to reset the filter status.");
+
+      SetRunStatePacket pkt = SetRunStatePacket();
+      pkt.set_filter_reset(true);
+      hp_bridge_.send_packet(pkt);
+    }
+
+  } // namespace mitsubishi_itp
+} // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -1,364 +1,293 @@
 #include "mitsubishi_itp.h"
 
-namespace esphome
-{
-  namespace mitsubishi_itp
-  {
+namespace esphome {
+namespace mitsubishi_itp {
 
-    ////
-    // MitsubishiUART
-    ////
+////
+// MitsubishiUART
+////
 
-    MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
-        : hp_uart_{*hp_uart_comp}, hp_bridge_{HeatpumpBridge(hp_uart_comp, this)}
-    {
-      /**
-       * Climate pushes all its data to Home Assistant immediately when the API connects, this causes
-       * the default 0 to be sent as temperatures, but since this is a valid value (0 deg C), it
-       * can cause confusion and mess with graphs when looking at the state in HA.  Setting this to
-       * NAN gets HA to treat this value as "unavailable" until we have a real value to publish.
-       */
-      target_temperature = NAN;
-      current_temperature = NAN;
-    }
+MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
+    : hp_uart_{*hp_uart_comp}, hp_bridge_{HeatpumpBridge(hp_uart_comp, this)} {
+  /**
+   * Climate pushes all its data to Home Assistant immediately when the API connects, this causes
+   * the default 0 to be sent as temperatures, but since this is a valid value (0 deg C), it
+   * can cause confusion and mess with graphs when looking at the state in HA.  Setting this to
+   * NAN gets HA to treat this value as "unavailable" until we have a real value to publish.
+   */
+  target_temperature = NAN;
+  current_temperature = NAN;
+}
 
-    // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
-    // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
-    void MitsubishiUART::setup()
-    {
-      for (auto *listener : listeners_)
-      {
-        listener->setup(bool(ts_uart_));
-      }
-      // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
-      // is an easy way to prevent wierd conflicts if e.g. select options change.
-      preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
-                                                                          fnv1_hash(App.get_compilation_time()));
-      restore_preferences_();
-    }
+// Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
+// Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+void MitsubishiUART::setup() {
+  for (auto *listener : listeners_) {
+    listener->setup(bool(ts_uart_));
+  }
+  // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
+  // is an easy way to prevent wierd conflicts if e.g. select options change.
+  preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
+                                                                      fnv1_hash(App.get_compilation_time()));
+  restore_preferences_();
+}
 
-    void MitsubishiUART::restore_preferences_()
-    {
-      MITPPreferences prefs;
-      if (preferences_.load(&prefs))
-      {
-        for (auto i = 0; i < MAX_RECALL_MODE_INDEX; i++)
-        {
-          if (prefs.modeRecallSetpoints[i] > 0)
-          {
-            // If any setpoints are set, assume valid preferences and load all of them
-            mode_recall_setpoints_ = prefs.modeRecallSetpoints;
-            ESP_LOGCONFIG(TAG, "Loaded mode recall setpoints.");
-            break;
-          }
-        }
+void MitsubishiUART::restore_preferences_() {
+  MITPPreferences prefs;
+  if (preferences_.load(&prefs)) {
+    for (auto i = 0; i < MAX_RECALL_MODE_INDEX; i++) {
+      if (prefs.modeRecallSetpoints[i] > 0) {
+        // If any setpoints are set, assume valid preferences and load all of them
+        mode_recall_setpoints_ = prefs.modeRecallSetpoints;
+        ESP_LOGCONFIG(TAG, "Loaded mode recall setpoints.");
+        break;
       }
     }
+  }
+}
 
-    void MitsubishiUART::save_preferences_()
-    {
-      MITPPreferences prefs{};
-      prefs.modeRecallSetpoints = mode_recall_setpoints_;
-      preferences_.save(&prefs);
+void MitsubishiUART::save_preferences_() {
+  MITPPreferences prefs{};
+  prefs.modeRecallSetpoints = mode_recall_setpoints_;
+  preferences_.save(&prefs);
+}
+
+/* Used for receiving and acting on incoming packets as soon as they're available.
+  Because packet processing happens as part of the receiving process, packet processing
+  should not block for very long (e.g. no publishing inside the packet processing)
+*/
+void MitsubishiUART::loop() {
+  // Loop bridge to handle sending and receiving packets
+  hp_bridge_.loop();
+  if (ts_bridge_)
+    ts_bridge_->loop();
+
+  if ((millis() - last_received_temperature_) > TEMPERATURE_SOURCE_TIMEOUT_MS) {
+    if (current_temperature_source_.empty() || current_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL) {
+      ESP_LOGD(TAG, "Reminding heat pump to use internal temperature sensor");
+      // Check to make sure a temperature source is set-- if not, set to internal for sanity reasons
+      this->select_temperature_source(TEMPERATURE_SOURCE_INTERNAL);
+      last_received_temperature_ = millis();  // Count this as "receiving" the internal temperature
+    } else if (!temperature_source_timeout_) {
+      // If it's been too long since we received a temperature update (and we're not set to Internal)
+      ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
+               current_temperature_source_.c_str(), (unsigned long) TEMPERATURE_SOURCE_TIMEOUT_MS);
+      // Let listeners know we've changed to the Internal temperature source (but do not change
+      // currentTemperatureSource)
+      for (auto *listener : listeners_) {
+        listener->temperature_source_change(TEMPERATURE_SOURCE_INTERNAL);
+      }
+      temperature_source_timeout_ = true;
+      // Send a packet to the heat pump to tell it to switch to internal temperature sensing
+      hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
     }
+  }
+}
 
-    /* Used for receiving and acting on incoming packets as soon as they're available.
-      Because packet processing happens as part of the receiving process, packet processing
-      should not block for very long (e.g. no publishing inside the packet processing)
-    */
-    void MitsubishiUART::loop()
-    {
-      // Loop bridge to handle sending and receiving packets
-      hp_bridge_.loop();
-      if (ts_bridge_)
-        ts_bridge_->loop();
+void MitsubishiUART::dump_config() {
+  if (capabilities_cache_.has_value()) {
+    ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
+  }
 
-      if ((millis() - last_received_temperature_) > TEMPERATURE_SOURCE_TIMEOUT_MS)
-      {
-        if (current_temperature_source_.empty() || current_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL)
-        {
-          ESP_LOGD(TAG, "Reminding heat pump to use internal temperature sensor");
-          // Check to make sure a temperature source is set-- if not, set to internal for sanity reasons
-          this->select_temperature_source(TEMPERATURE_SOURCE_INTERNAL);
-          last_received_temperature_ = millis(); // Count this as "receiving" the internal temperature
-        }
-        else if (!temperature_source_timeout_)
-        {
-          // If it's been too long since we received a temperature update (and we're not set to Internal)
-          ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
-                   current_temperature_source_.c_str(), (unsigned long)TEMPERATURE_SOURCE_TIMEOUT_MS);
-          // Let listeners know we've changed to the Internal temperature source (but do not change
-          // currentTemperatureSource)
-          for (auto *listener : listeners_)
-          {
-            listener->temperature_source_change(TEMPERATURE_SOURCE_INTERNAL);
-          }
-          temperature_source_timeout_ = true;
-          // Send a packet to the heat pump to tell it to switch to internal temperature sensing
-          hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
-        }
-      }
-    }
+  if (enhanced_mhk_support_) {
+    ESP_LOGCONFIG(TAG, "MHK Enhanced Protocol Mode is ENABLED! This is currently *experimental* and things may break!");
+  }
+}
 
-    void MitsubishiUART::dump_config()
-    {
-      if (capabilities_cache_.has_value())
-      {
-        ESP_LOGCONFIG(TAG, "Discovered Capabilities: %s", capabilities_cache_.value().to_string().c_str());
-      }
+// Set thermostat UART component
+void MitsubishiUART::set_thermostat_uart(uart::UARTComponent *uart) {
+  ESP_LOGCONFIG(TAG, "Thermostat uart was set.");
+  ts_uart_ = uart;
+  ts_bridge_ = make_unique<ThermostatBridge>(ts_uart_, static_cast<PacketProcessor *>(this));
+}
 
-      if (enhanced_mhk_support_)
-      {
-        ESP_LOGCONFIG(TAG, "MHK Enhanced Protocol Mode is ENABLED! This is currently *experimental* and things may break!");
-      }
-    }
+/* Called periodically as PollingComponent; used to send packets to connect or request updates.
 
-    // Set thermostat UART component
-    void MitsubishiUART::set_thermostat_uart(uart::UARTComponent *uart)
-    {
-      ESP_LOGCONFIG(TAG, "Thermostat uart was set.");
-      ts_uart_ = uart;
-      ts_bridge_ = make_unique<ThermostatBridge>(ts_uart_, static_cast<PacketProcessor *>(this));
-    }
+Possible TODO: If we only publish during updates, since data is received during loop, updates will always
+be about `update_interval` late from their actual time.  Generally the update interval should be low enough
+(default is 5seconds) this won't pose a practical problem.
+*/
+void MitsubishiUART::update() {
+  // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
+  if (millis() < 5000) {
+    return;
+  }
 
-    /* Called periodically as PollingComponent; used to send packets to connect or request updates.
+  // If we're not yet connected, send off a connection request (we'll check again next update)
+  if (!hp_connected_) {
+    hp_bridge_.send_packet(ConnectRequestPacket::instance());
+    return;
+  }
 
-    Possible TODO: If we only publish during updates, since data is received during loop, updates will always
-    be about `update_interval` late from their actual time.  Generally the update interval should be low enough
-    (default is 5seconds) this won't pose a practical problem.
-    */
-    void MitsubishiUART::update()
-    {
-      // TODO: Temporarily wait 5 seconds on startup to help with viewing logs
-      if (millis() < 5000)
-      {
-        return;
-      }
+  // Attempt to read capabilities on the next loop after connect.
+  // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper
+  // autoconf.
+  //       For now, just requesting it as part of our "init loops" is a good first step.
+  if (!this->capabilities_requested_) {
+    hp_bridge_.send_packet(CapabilitiesRequestPacket::instance());
+    this->capabilities_requested_ = true;
+  }
 
-      // If we're not yet connected, send off a connection request (we'll check again next update)
-      if (!hp_connected_)
-      {
-        hp_bridge_.send_packet(ConnectRequestPacket::instance());
-        return;
-      }
+  // Before requesting additional updates, publish any changes waiting from packets received
 
-      // Attempt to read capabilities on the next loop after connect.
-      // TODO: This should likely be done immediately after connect, and will likely need to block setup for proper
-      // autoconf.
-      //       For now, just requesting it as part of our "init loops" is a good first step.
-      if (!this->capabilities_requested_)
-      {
-        hp_bridge_.send_packet(CapabilitiesRequestPacket::instance());
-        this->capabilities_requested_ = true;
-      }
+  // Notify all listeners a publish is happening, they will decide if actual publish is needed.
+  for (auto *listener : listeners_) {
+    listener->publish();
+  }
 
-      // Before requesting additional updates, publish any changes waiting from packets received
+  if (publish_on_update_) {
+    do_publish_();
 
-      // Notify all listeners a publish is happening, they will decide if actual publish is needed.
-      for (auto *listener : listeners_)
-      {
-        listener->publish();
-      }
+    publish_on_update_ = false;
+  }
 
-      if (publish_on_update_)
-      {
-        do_publish_();
+  // Request an update from the heatpump
+  // TODO: This isn't a problem *yet*, but sending all these packets every loop might start to cause some issues
+  // in
+  //       certain configurations or setups. We may want to consider only asking for certain packets on a rarer
+  //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
+  hp_bridge_.send_packet(
+      GetRequestPacket::get_settings_instance());  // Needs to be done before status packet for mode logic to work
+  if (in_discovery_ || run_state_received_) {
+    hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
+  }
 
-        publish_on_update_ = false;
-      }
+  hp_bridge_.send_packet(GetRequestPacket::get_status_instance());
+  hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
+  hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());
 
-      // Request an update from the heatpump
-      // TODO: This isn't a problem *yet*, but sending all these packets every loop might start to cause some issues
-      // in
-      //       certain configurations or setups. We may want to consider only asking for certain packets on a rarer
-      //       cadence, depending on their utility (e.g. we dont need to check for errors every loop).
-      hp_bridge_.send_packet(
-          GetRequestPacket::get_settings_instance()); // Needs to be done before status packet for mode logic to work
-      if (in_discovery_ || run_state_received_)
-      {
-        hp_bridge_.send_packet(GetRequestPacket::get_runstate_instance());
-      }
+  if (in_discovery_) {
+    // After criteria met, exit discovery mode
+    // Currently this is either 5 updates or a successful RunState response.
+    if (discovery_updates_++ > 5 || run_state_received_) {
+      ESP_LOGD(TAG, "Discovery complete.");
+      in_discovery_ = false;
 
-      hp_bridge_.send_packet(GetRequestPacket::get_status_instance());
-      hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
-      hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());
-
-      if (in_discovery_)
-      {
-        // After criteria met, exit discovery mode
-        // Currently this is either 5 updates or a successful RunState response.
-        if (discovery_updates_++ > 5 || run_state_received_)
-        {
-          ESP_LOGD(TAG, "Discovery complete.");
-          in_discovery_ = false;
-
-          if (!run_state_received_)
-          {
-            ESP_LOGI(TAG, "RunState packets not supported.");
-          }
-        }
+      if (!run_state_received_) {
+        ESP_LOGI(TAG, "RunState packets not supported.");
       }
     }
+  }
+}
 
-    void MitsubishiUART::do_publish_()
-    {
-      publish_state();
-      // We can safely do this on every publish as ESPPreferences collects changes and only writes if different
-      save_preferences_();
+void MitsubishiUART::do_publish_() {
+  publish_state();
+  // We can safely do this on every publish as ESPPreferences collects changes and only writes if different
+  save_preferences_();
+}
+
+bool MitsubishiUART::select_temperature_source(const std::string &state) {
+  // TODO: Possibly check to see if state is available from the select options?  (Might be a bit redundant)
+
+  current_temperature_source_ = state;
+  // Reset the timeout for received temperature (without this, the menu dropdown will switch back to Internal
+  // temporarily)
+  last_received_temperature_ = millis();
+
+  // If we've switched to internal, let the HP know right away
+  if (TEMPERATURE_SOURCE_INTERNAL == state) {
+    hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
+  }
+
+  return true;
+}
+
+bool MitsubishiUART::select_vane_position(const std::string &state) {
+  SettingsSetRequestPacket::VaneByte position_byte = SettingsSetRequestPacket::VANE_AUTO;
+
+  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+  // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+  if (state == "Auto") {
+    position_byte = SettingsSetRequestPacket::VANE_AUTO;
+  } else if (state == "1") {
+    position_byte = SettingsSetRequestPacket::VANE_1;
+  } else if (state == "2") {
+    position_byte = SettingsSetRequestPacket::VANE_2;
+  } else if (state == "3") {
+    position_byte = SettingsSetRequestPacket::VANE_3;
+  } else if (state == "4") {
+    position_byte = SettingsSetRequestPacket::VANE_4;
+  } else if (state == "5") {
+    position_byte = SettingsSetRequestPacket::VANE_5;
+  } else if (state == "Swing") {
+    position_byte = SettingsSetRequestPacket::VANE_SWING;
+  } else {
+    ESP_LOGW(TAG, "Unknown vane position %s", state.c_str());
+    return false;
+  }
+
+  hp_bridge_.send_packet(SettingsSetRequestPacket().set_vane(position_byte));
+  return true;
+}
+
+bool MitsubishiUART::select_horizontal_vane_position(const std::string &state) {
+  SettingsSetRequestPacket::HorizontalVaneByte position_byte = SettingsSetRequestPacket::HV_CENTER;
+
+  // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
+  // infrequently, this is probably a better solution than over-optimizing via maps or something
+
+  if (state == "Auto") {
+    position_byte = SettingsSetRequestPacket::HV_AUTO;
+  } else if (state == "<<") {
+    position_byte = SettingsSetRequestPacket::HV_LEFT_FULL;
+  } else if (state == "<") {
+    position_byte = SettingsSetRequestPacket::HV_LEFT;
+  } else if (state == "|") {
+    position_byte = SettingsSetRequestPacket::HV_CENTER;
+  } else if (state == ">") {
+    position_byte = SettingsSetRequestPacket::HV_RIGHT;
+  } else if (state == ">>") {
+    position_byte = SettingsSetRequestPacket::HV_RIGHT_FULL;
+  } else if (state == "<>") {
+    position_byte = SettingsSetRequestPacket::HV_SPLIT;
+  } else if (state == "Swing") {
+    position_byte = SettingsSetRequestPacket::HV_SWING;
+  } else {
+    ESP_LOGW(TAG, "Unknown horizontal vane position %s", state.c_str());
+    return false;
+  }
+
+  hp_bridge_.send_packet(SettingsSetRequestPacket().set_horizontal_vane(position_byte));
+  return true;
+}
+
+// Called by temperature_source sensors to report values.  Will only take action if the currentTemperatureSource
+// matches the incoming source.  Specifically this means that we are not storing any values
+// for sensors other than the current source, and selecting a different source won't have any
+// effect until that source reports a temperature.
+// TODO: ? Maybe store all temperatures (and report on them using internal sensors??) so that selecting a new
+// source takes effect immediately?  Only really needed if source sensors are configured with very slow update times.
+void MitsubishiUART::temperature_source_report(const std::string &temperature_source, const float &v) {
+  ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
+           current_temperature_source_.c_str());
+
+  // Only proceed if the incomming source matches our chosen source.
+  if (current_temperature_source_ == temperature_source) {
+    // Reset the timeout for received temperature
+    last_received_temperature_ = millis();
+    temperature_source_timeout_ = false;
+
+    // Tell the heat pump about the temperature asap, but don't worry about setting it locally, the next update() will
+    // get it
+    RemoteTemperatureSetRequestPacket pkt = RemoteTemperatureSetRequestPacket();
+    pkt.set_remote_temperature(v);
+    hp_bridge_.send_packet(pkt);
+
+    // If we've changed the select to reflect a temporary reversion to a different source, change it back.
+    for (auto *listener : listeners_) {
+      listener->temperature_source_change(current_temperature_source_);
     }
+  }
+}
 
-    bool MitsubishiUART::select_temperature_source(const std::string &state)
-    {
-      // TODO: Possibly check to see if state is available from the select options?  (Might be a bit redundant)
+void MitsubishiUART::reset_filter_status() {
+  ESP_LOGI(TAG, "Received a request to reset the filter status.");
 
-      current_temperature_source_ = state;
-      // Reset the timeout for received temperature (without this, the menu dropdown will switch back to Internal
-      // temporarily)
-      last_received_temperature_ = millis();
+  SetRunStatePacket pkt = SetRunStatePacket();
+  pkt.set_filter_reset(true);
+  hp_bridge_.send_packet(pkt);
+}
 
-      // If we've switched to internal, let the HP know right away
-      if (TEMPERATURE_SOURCE_INTERNAL == state)
-      {
-        hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().use_internal_temperature());
-      }
-
-      return true;
-    }
-
-    bool MitsubishiUART::select_vane_position(const std::string &state)
-    {
-      SettingsSetRequestPacket::VaneByte position_byte = SettingsSetRequestPacket::VANE_AUTO;
-
-      // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
-      // infrequently, this is probably a better solution than over-optimizing via maps or something
-
-      if (state == "Auto")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_AUTO;
-      }
-      else if (state == "1")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_1;
-      }
-      else if (state == "2")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_2;
-      }
-      else if (state == "3")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_3;
-      }
-      else if (state == "4")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_4;
-      }
-      else if (state == "5")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_5;
-      }
-      else if (state == "Swing")
-      {
-        position_byte = SettingsSetRequestPacket::VANE_SWING;
-      }
-      else
-      {
-        ESP_LOGW(TAG, "Unknown vane position %s", state.c_str());
-        return false;
-      }
-
-      hp_bridge_.send_packet(SettingsSetRequestPacket().set_vane(position_byte));
-      return true;
-    }
-
-    bool MitsubishiUART::select_horizontal_vane_position(const std::string &state)
-    {
-      SettingsSetRequestPacket::HorizontalVaneByte position_byte = SettingsSetRequestPacket::HV_CENTER;
-
-      // NOTE: Annoyed that C++ doesn't have switches for strings, but since this is going to be called
-      // infrequently, this is probably a better solution than over-optimizing via maps or something
-
-      if (state == "Auto")
-      {
-        position_byte = SettingsSetRequestPacket::HV_AUTO;
-      }
-      else if (state == "<<")
-      {
-        position_byte = SettingsSetRequestPacket::HV_LEFT_FULL;
-      }
-      else if (state == "<")
-      {
-        position_byte = SettingsSetRequestPacket::HV_LEFT;
-      }
-      else if (state == "|")
-      {
-        position_byte = SettingsSetRequestPacket::HV_CENTER;
-      }
-      else if (state == ">")
-      {
-        position_byte = SettingsSetRequestPacket::HV_RIGHT;
-      }
-      else if (state == ">>")
-      {
-        position_byte = SettingsSetRequestPacket::HV_RIGHT_FULL;
-      }
-      else if (state == "<>")
-      {
-        position_byte = SettingsSetRequestPacket::HV_SPLIT;
-      }
-      else if (state == "Swing")
-      {
-        position_byte = SettingsSetRequestPacket::HV_SWING;
-      }
-      else
-      {
-        ESP_LOGW(TAG, "Unknown horizontal vane position %s", state.c_str());
-        return false;
-      }
-
-      hp_bridge_.send_packet(SettingsSetRequestPacket().set_horizontal_vane(position_byte));
-      return true;
-    }
-
-    // Called by temperature_source sensors to report values.  Will only take action if the currentTemperatureSource
-    // matches the incoming source.  Specifically this means that we are not storing any values
-    // for sensors other than the current source, and selecting a different source won't have any
-    // effect until that source reports a temperature.
-    // TODO: ? Maybe store all temperatures (and report on them using internal sensors??) so that selecting a new
-    // source takes effect immediately?  Only really needed if source sensors are configured with very slow update times.
-    void MitsubishiUART::temperature_source_report(const std::string &temperature_source, const float &v)
-    {
-      ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
-               current_temperature_source_.c_str());
-
-      // Only proceed if the incomming source matches our chosen source.
-      if (current_temperature_source_ == temperature_source)
-      {
-        // Reset the timeout for received temperature
-        last_received_temperature_ = millis();
-        temperature_source_timeout_ = false;
-
-        // Tell the heat pump about the temperature asap, but don't worry about setting it locally, the next update() will
-        // get it
-        RemoteTemperatureSetRequestPacket pkt = RemoteTemperatureSetRequestPacket();
-        pkt.set_remote_temperature(v);
-        hp_bridge_.send_packet(pkt);
-
-        // If we've changed the select to reflect a temporary reversion to a different source, change it back.
-        for (auto *listener : listeners_)
-        {
-          listener->temperature_source_change(current_temperature_source_);
-        }
-      }
-    }
-
-    void MitsubishiUART::reset_filter_status()
-    {
-      ESP_LOGI(TAG, "Received a request to reset the filter status.");
-
-      SetRunStatePacket pkt = SetRunStatePacket();
-      pkt.set_filter_reset(true);
-      hp_bridge_.send_packet(pkt);
-    }
-
-  } // namespace mitsubishi_itp
-} // namespace esphome
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -13,197 +13,186 @@
 #include "mitp_mhk.h"
 #include <map>
 
-namespace esphome
-{
-  namespace mitsubishi_itp
-  {
+namespace esphome {
+namespace mitsubishi_itp {
 
-    static constexpr char TAG[] = "mitsubishi_itp";
+static constexpr char TAG[] = "mitsubishi_itp";
 
-    const uint8_t MITP_MIN_TEMP = 16; // Degrees C
-    const uint8_t MITP_MAX_TEMP = 31; // Degrees C
-    const float MITP_TEMPERATURE_STEP = 0.5;
+const uint8_t MITP_MIN_TEMP = 16;  // Degrees C
+const uint8_t MITP_MAX_TEMP = 31;  // Degrees C
+const float MITP_TEMPERATURE_STEP = 0.5;
 
-    const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
-    const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
+const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
-    const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000; // (7min) The heatpump will revert on its own in ~10min
+const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000;  // (7min) The heatpump will revert on its own in ~10min
 
-    const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
+const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
 
-    class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor
-    {
-    public:
-      /**
-       * Create a new MitsubishiUART with the specified esphome::uart::UARTComponent.
-       */
-      MitsubishiUART(uart::UARTComponent *hp_uart_comp);
+class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
+ public:
+  /**
+   * Create a new MitsubishiUART with the specified esphome::uart::UARTComponent.
+   */
+  MitsubishiUART(uart::UARTComponent *hp_uart_comp);
 
-      // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
-      // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
-      void setup() override;
+  // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
+  // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+  void setup() override;
 
-      // Called repeatedly (used for UART receiving/forwarding)
-      void loop() override;
+  // Called repeatedly (used for UART receiving/forwarding)
+  void loop() override;
 
-      // Called periodically as PollingComponent (used for UART sending periodically)
-      void update() override;
+  // Called periodically as PollingComponent (used for UART sending periodically)
+  void update() override;
 
-      // Returns default traits for MITP
-      climate::ClimateTraits traits() override { return climate_traits_; }
+  // Returns default traits for MITP
+  climate::ClimateTraits traits() override { return climate_traits_; }
 
-      // Returns a reference to traits for MITP to be used during configuration
-      // TODO: Maybe replace this with specific functions for the traits needed in configuration (a la the override
-      // fuctions)
-      climate::ClimateTraits &config_traits() { return climate_traits_; }
+  // Returns a reference to traits for MITP to be used during configuration
+  // TODO: Maybe replace this with specific functions for the traits needed in configuration (a la the override
+  // fuctions)
+  climate::ClimateTraits &config_traits() { return climate_traits_; }
 
-      // Dumps some configuration data that we may have missed in the real-time logs
-      void dump_config() override;
+  // Dumps some configuration data that we may have missed in the real-time logs
+  void dump_config() override;
 
-      // Called to instruct a change of the climate controls
-      void control(const climate::ClimateCall &call) override;
+  // Called to instruct a change of the climate controls
+  void control(const climate::ClimateCall &call) override;
 
-      // Set thermostat UART component
-      void set_thermostat_uart(uart::UARTComponent *uart);
+  // Set thermostat UART component
+  void set_thermostat_uart(uart::UARTComponent *uart);
 
-      // Listener-sensors
-      void register_listener(MITPListener *listener) { this->listeners_.push_back(listener); }
+  // Listener-sensors
+  void register_listener(MITPListener *listener) { this->listeners_.push_back(listener); }
 
-      // Returns true if select was valid (even if not yet successful) to indicate select component
-      // should optimistically publish
-      bool select_temperature_source(const std::string &state);
-      bool select_vane_position(const std::string &state);
-      bool select_horizontal_vane_position(const std::string &state);
+  // Returns true if select was valid (even if not yet successful) to indicate select component
+  // should optimistically publish
+  bool select_temperature_source(const std::string &state);
+  bool select_vane_position(const std::string &state);
+  bool select_horizontal_vane_position(const std::string &state);
 
-      // Used by external sources to report a temperature
-      void temperature_source_report(const std::string &temperature_source, const float &v);
+  // Used by external sources to report a temperature
+  void temperature_source_report(const std::string &temperature_source, const float &v);
 
-      // Button triggers
-      void reset_filter_status();
+  // Button triggers
+  void reset_filter_status();
 
-      // Turns on or off Kumo emulation mode
-      void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
+  // Turns on or off Kumo emulation mode
+  void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
 
-      // Enables the recall setpoint feature
-      void set_recall_setpoint(const bool enabled) { recall_setpoint_ = enabled; }
+  // Enables the recall setpoint feature
+  void set_recall_setpoint(const bool enabled) { recall_setpoint_ = enabled; }
 
 #ifdef USE_TIME
-      void set_time_source(time::RealTimeClock *rtc)
-      {
-        time_source_ = rtc;
-      }
+  void set_time_source(time::RealTimeClock *rtc) { time_source_ = rtc; }
 #endif
 
-    protected:
-      void route_packet_(const Packet &packet);
+ protected:
+  void route_packet_(const Packet &packet);
 
-      void process_packet(const Packet &packet) override;
-      void process_packet(const ConnectRequestPacket &packet) override;
-      void process_packet(const ConnectResponsePacket &packet) override;
-      void process_packet(const CapabilitiesRequestPacket &packet) override;
-      void process_packet(const CapabilitiesResponsePacket &packet) override;
-      void process_packet(const GetRequestPacket &packet) override;
-      void process_packet(const SettingsGetResponsePacket &packet) override;
-      void process_packet(const CurrentTempGetResponsePacket &packet) override;
-      void process_packet(const StatusGetResponsePacket &packet) override;
-      void process_packet(const RunStateGetResponsePacket &packet) override;
-      void process_packet(const ErrorStateGetResponsePacket &packet) override;
-      void process_packet(const Functions1GetResponsePacket &packet) override;
-      void process_packet(const Functions2GetResponsePacket &packet) override;
-      void process_packet(const SettingsSetRequestPacket &packet) override;
-      void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
-      void process_packet(const ThermostatSensorStatusPacket &packet) override;
-      void process_packet(const ThermostatHelloPacket &packet) override;
-      void process_packet(const ThermostatStateUploadPacket &packet) override;
-      void process_packet(const ThermostatAASetRequestPacket &packet) override;
-      void process_packet(const SetResponsePacket &packet) override;
+  void process_packet(const Packet &packet) override;
+  void process_packet(const ConnectRequestPacket &packet) override;
+  void process_packet(const ConnectResponsePacket &packet) override;
+  void process_packet(const CapabilitiesRequestPacket &packet) override;
+  void process_packet(const CapabilitiesResponsePacket &packet) override;
+  void process_packet(const GetRequestPacket &packet) override;
+  void process_packet(const SettingsGetResponsePacket &packet) override;
+  void process_packet(const CurrentTempGetResponsePacket &packet) override;
+  void process_packet(const StatusGetResponsePacket &packet) override;
+  void process_packet(const RunStateGetResponsePacket &packet) override;
+  void process_packet(const ErrorStateGetResponsePacket &packet) override;
+  void process_packet(const Functions1GetResponsePacket &packet) override;
+  void process_packet(const Functions2GetResponsePacket &packet) override;
+  void process_packet(const SettingsSetRequestPacket &packet) override;
+  void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
+  void process_packet(const ThermostatSensorStatusPacket &packet) override;
+  void process_packet(const ThermostatHelloPacket &packet) override;
+  void process_packet(const ThermostatStateUploadPacket &packet) override;
+  void process_packet(const ThermostatAASetRequestPacket &packet) override;
+  void process_packet(const SetResponsePacket &packet) override;
 
-      void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
-      void handle_thermostat_ab_get_request(const GetRequestPacket &packet) override;
+  void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
+  void handle_thermostat_ab_get_request(const GetRequestPacket &packet) override;
 
-      void do_publish_();
+  void do_publish_();
 
-    private:
-      // Default climate_traits for MITP
-      climate::ClimateTraits climate_traits_ = []() -> climate::ClimateTraits
-      {
-        climate::ClimateTraits ct = climate::ClimateTraits();
+ private:
+  // Default climate_traits for MITP
+  climate::ClimateTraits climate_traits_ = []() -> climate::ClimateTraits {
+    climate::ClimateTraits ct = climate::ClimateTraits();
 
-        ct.set_supports_action(true);
-        ct.set_supports_current_temperature(true);
-        ct.set_supports_two_point_target_temperature(false);
-        ct.set_visual_min_temperature(MITP_MIN_TEMP);
-        ct.set_visual_max_temperature(MITP_MAX_TEMP);
-        ct.set_visual_temperature_step(MITP_TEMPERATURE_STEP);
+    ct.set_supports_action(true);
+    ct.set_supports_current_temperature(true);
+    ct.set_supports_two_point_target_temperature(false);
+    ct.set_visual_min_temperature(MITP_MIN_TEMP);
+    ct.set_visual_max_temperature(MITP_MAX_TEMP);
+    ct.set_visual_temperature_step(MITP_TEMPERATURE_STEP);
 
-        return ct;
-      }();
+    return ct;
+  }();
 
-      // UARTComponent connected to heatpump
-      const uart::UARTComponent &hp_uart_;
-      // UART packet wrapper for heatpump
-      HeatpumpBridge hp_bridge_;
-      // UARTComponent connected to thermostat
-      uart::UARTComponent *ts_uart_ = nullptr;
-      // UART packet wrapper for heatpump
-      std::unique_ptr<ThermostatBridge> ts_bridge_ = nullptr;
+  // UARTComponent connected to heatpump
+  const uart::UARTComponent &hp_uart_;
+  // UART packet wrapper for heatpump
+  HeatpumpBridge hp_bridge_;
+  // UARTComponent connected to thermostat
+  uart::UARTComponent *ts_uart_ = nullptr;
+  // UART packet wrapper for heatpump
+  std::unique_ptr<ThermostatBridge> ts_bridge_ = nullptr;
 
-      // Are we connected to the heatpump?
-      bool hp_connected_ = false;
-      // Should we call publish on the next update?
-      bool publish_on_update_ = false;
-      // Are we still discovering information about the device?
-      bool in_discovery_ = true;
-      // Number of times update() has been called in discovery mode
-      size_t discovery_updates_ = 0;
+  // Are we connected to the heatpump?
+  bool hp_connected_ = false;
+  // Should we call publish on the next update?
+  bool publish_on_update_ = false;
+  // Are we still discovering information about the device?
+  bool in_discovery_ = true;
+  // Number of times update() has been called in discovery mode
+  size_t discovery_updates_ = 0;
 
-      optional<CapabilitiesResponsePacket> capabilities_cache_;
-      bool capabilities_requested_ = false;
-      // Have we received at least one RunState response?
-      bool run_state_received_ = false;
+  optional<CapabilitiesResponsePacket> capabilities_cache_;
+  bool capabilities_requested_ = false;
+  // Have we received at least one RunState response?
+  bool run_state_received_ = false;
 
 // Time Source
 #ifdef USE_TIME
-      time::RealTimeClock *time_source_ = nullptr;
+  time::RealTimeClock *time_source_ = nullptr;
 #endif
 
-      // Listener-sensors
-      std::vector<MITPListener *> listeners_{};
-      template <typename T>
-      void alert_listeners_(const T &packet) const
-      {
-        for (auto *listener : this->listeners_)
-        {
-          listener->process_packet(packet);
-        }
-      }
+  // Listener-sensors
+  std::vector<MITPListener *> listeners_{};
+  template<typename T> void alert_listeners_(const T &packet) const {
+    for (auto *listener : this->listeners_) {
+      listener->process_packet(packet);
+    }
+  }
 
-      // Temperature select extras
-      std::string current_temperature_source_;
-      uint32_t last_received_temperature_ = millis();
-      bool temperature_source_timeout_ = false; // Has the current source timed out?
+  // Temperature select extras
+  std::string current_temperature_source_;
+  uint32_t last_received_temperature_ = millis();
+  bool temperature_source_timeout_ = false;  // Has the current source timed out?
 
-      // used to track whether to support/handle the enhanced MHK protocol packets
-      bool enhanced_mhk_support_ = false;
+  // used to track whether to support/handle the enhanced MHK protocol packets
+  bool enhanced_mhk_support_ = false;
 
-      // If enabled, switching modes will recall target mode's previous setpoint
-      bool recall_setpoint_ = false;
-      // Array stores a float setpoint for each climate mode up to DRY.
-      std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_;
+  // If enabled, switching modes will recall target mode's previous setpoint
+  bool recall_setpoint_ = false;
+  // Array stores a float setpoint for each climate mode up to DRY.
+  std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_;
 
-      MHKState mhk_state_;
+  MHKState mhk_state_;
 
-      // Preferences
-      void save_preferences_();
-      void restore_preferences_();
-      ESPPreferenceObject preferences_;
-    };
+  // Preferences
+  void save_preferences_();
+  void restore_preferences_();
+  ESPPreferenceObject preferences_;
+};
 
-    struct MITPPreferences
-    {
-      // Array stores a float setpoint for each climate mode up to DRY.
-      std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints;
-    };
+struct MITPPreferences {
+  // Array stores a float setpoint for each climate mode up to DRY.
+  std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints;
+};
 
-  } // namespace mitsubishi_itp
-} // namespace esphome
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -13,192 +13,197 @@
 #include "mitp_mhk.h"
 #include <map>
 
-namespace esphome {
-namespace mitsubishi_itp {
+namespace esphome
+{
+  namespace mitsubishi_itp
+  {
 
-static constexpr char TAG[] = "mitsubishi_itp";
+    static constexpr char TAG[] = "mitsubishi_itp";
 
-const uint8_t MITP_MIN_TEMP = 16;  // Degrees C
-const uint8_t MITP_MAX_TEMP = 31;  // Degrees C
-const float MITP_TEMPERATURE_STEP = 0.5;
+    const uint8_t MITP_MIN_TEMP = 16; // Degrees C
+    const uint8_t MITP_MAX_TEMP = 31; // Degrees C
+    const float MITP_TEMPERATURE_STEP = 0.5;
 
-const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
-const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+    const std::string TEMPERATURE_SOURCE_INTERNAL = "Internal";
+    const std::string TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
-const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000;  // (7min) The heatpump will revert on its own in ~10min
+    const uint32_t TEMPERATURE_SOURCE_TIMEOUT_MS = 420000; // (7min) The heatpump will revert on its own in ~10min
 
-const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
+    const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
 
-class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor {
- public:
-  /**
-   * Create a new MitsubishiUART with the specified esphome::uart::UARTComponent.
-   */
-  MitsubishiUART(uart::UARTComponent *hp_uart_comp);
+    class MitsubishiUART : public PollingComponent, public climate::Climate, public PacketProcessor
+    {
+    public:
+      /**
+       * Create a new MitsubishiUART with the specified esphome::uart::UARTComponent.
+       */
+      MitsubishiUART(uart::UARTComponent *hp_uart_comp);
 
-  // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
-  // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
-  void setup() override;
+      // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
+      // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
+      void setup() override;
 
-  // Called repeatedly (used for UART receiving/forwarding)
-  void loop() override;
+      // Called repeatedly (used for UART receiving/forwarding)
+      void loop() override;
 
-  // Called periodically as PollingComponent (used for UART sending periodically)
-  void update() override;
+      // Called periodically as PollingComponent (used for UART sending periodically)
+      void update() override;
 
-  // Returns default traits for MITP
-  climate::ClimateTraits traits() override { return climate_traits_; }
+      // Returns default traits for MITP
+      climate::ClimateTraits traits() override { return climate_traits_; }
 
-  // Returns a reference to traits for MITP to be used during configuration
-  // TODO: Maybe replace this with specific functions for the traits needed in configuration (a la the override
-  // fuctions)
-  climate::ClimateTraits &config_traits() { return climate_traits_; }
+      // Returns a reference to traits for MITP to be used during configuration
+      // TODO: Maybe replace this with specific functions for the traits needed in configuration (a la the override
+      // fuctions)
+      climate::ClimateTraits &config_traits() { return climate_traits_; }
 
-  // Dumps some configuration data that we may have missed in the real-time logs
-  void dump_config() override;
+      // Dumps some configuration data that we may have missed in the real-time logs
+      void dump_config() override;
 
-  // Called to instruct a change of the climate controls
-  void control(const climate::ClimateCall &call) override;
+      // Called to instruct a change of the climate controls
+      void control(const climate::ClimateCall &call) override;
 
-  // Set thermostat UART component
-  void set_thermostat_uart(uart::UARTComponent *uart);
+      // Set thermostat UART component
+      void set_thermostat_uart(uart::UARTComponent *uart);
 
-  // Listener-sensors
-  void register_listener(MITPListener *listener) { this->listeners_.push_back(listener); }
+      // Listener-sensors
+      void register_listener(MITPListener *listener) { this->listeners_.push_back(listener); }
 
-  // Returns true if select was valid (even if not yet successful) to indicate select component
-  // should optimistically publish
-  bool select_temperature_source(const std::string &state);
-  bool select_vane_position(const std::string &state);
-  bool select_horizontal_vane_position(const std::string &state);
+      // Returns true if select was valid (even if not yet successful) to indicate select component
+      // should optimistically publish
+      bool select_temperature_source(const std::string &state);
+      bool select_vane_position(const std::string &state);
+      bool select_horizontal_vane_position(const std::string &state);
 
-  // Used by external sources to report a temperature
-  void temperature_source_report(const std::string &temperature_source, const float &v);
+      // Used by external sources to report a temperature
+      void temperature_source_report(const std::string &temperature_source, const float &v);
 
-  // Button triggers
-  void reset_filter_status();
+      // Button triggers
+      void reset_filter_status();
 
-  // Turns on or off actively sending packets
-  void set_active_mode(const bool active) { active_mode_ = active; };
+      // Turns on or off Kumo emulation mode
+      void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
 
-  // Turns on or off Kumo emulation mode
-  void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
-
-  // Enables the recall setpoint feature
-  void set_recall_setpoint(const bool enabled) { recall_setpoint_ = enabled; }
+      // Enables the recall setpoint feature
+      void set_recall_setpoint(const bool enabled) { recall_setpoint_ = enabled; }
 
 #ifdef USE_TIME
-  void set_time_source(time::RealTimeClock *rtc) { time_source_ = rtc; }
+      void set_time_source(time::RealTimeClock *rtc)
+      {
+        time_source_ = rtc;
+      }
 #endif
 
- protected:
-  void route_packet_(const Packet &packet);
+    protected:
+      void route_packet_(const Packet &packet);
 
-  void process_packet(const Packet &packet) override;
-  void process_packet(const ConnectRequestPacket &packet) override;
-  void process_packet(const ConnectResponsePacket &packet) override;
-  void process_packet(const CapabilitiesRequestPacket &packet) override;
-  void process_packet(const CapabilitiesResponsePacket &packet) override;
-  void process_packet(const GetRequestPacket &packet) override;
-  void process_packet(const SettingsGetResponsePacket &packet) override;
-  void process_packet(const CurrentTempGetResponsePacket &packet) override;
-  void process_packet(const StatusGetResponsePacket &packet) override;
-  void process_packet(const RunStateGetResponsePacket &packet) override;
-  void process_packet(const ErrorStateGetResponsePacket &packet) override;
-  void process_packet(const Functions1GetResponsePacket &packet) override;
-  void process_packet(const Functions2GetResponsePacket &packet) override;
-  void process_packet(const SettingsSetRequestPacket &packet) override;
-  void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
-  void process_packet(const ThermostatSensorStatusPacket &packet) override;
-  void process_packet(const ThermostatHelloPacket &packet) override;
-  void process_packet(const ThermostatStateUploadPacket &packet) override;
-  void process_packet(const ThermostatAASetRequestPacket &packet) override;
-  void process_packet(const SetResponsePacket &packet) override;
+      void process_packet(const Packet &packet) override;
+      void process_packet(const ConnectRequestPacket &packet) override;
+      void process_packet(const ConnectResponsePacket &packet) override;
+      void process_packet(const CapabilitiesRequestPacket &packet) override;
+      void process_packet(const CapabilitiesResponsePacket &packet) override;
+      void process_packet(const GetRequestPacket &packet) override;
+      void process_packet(const SettingsGetResponsePacket &packet) override;
+      void process_packet(const CurrentTempGetResponsePacket &packet) override;
+      void process_packet(const StatusGetResponsePacket &packet) override;
+      void process_packet(const RunStateGetResponsePacket &packet) override;
+      void process_packet(const ErrorStateGetResponsePacket &packet) override;
+      void process_packet(const Functions1GetResponsePacket &packet) override;
+      void process_packet(const Functions2GetResponsePacket &packet) override;
+      void process_packet(const SettingsSetRequestPacket &packet) override;
+      void process_packet(const RemoteTemperatureSetRequestPacket &packet) override;
+      void process_packet(const ThermostatSensorStatusPacket &packet) override;
+      void process_packet(const ThermostatHelloPacket &packet) override;
+      void process_packet(const ThermostatStateUploadPacket &packet) override;
+      void process_packet(const ThermostatAASetRequestPacket &packet) override;
+      void process_packet(const SetResponsePacket &packet) override;
 
-  void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
-  void handle_thermostat_ab_get_request(const GetRequestPacket &packet) override;
+      void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
+      void handle_thermostat_ab_get_request(const GetRequestPacket &packet) override;
 
-  void do_publish_();
+      void do_publish_();
 
- private:
-  // Default climate_traits for MITP
-  climate::ClimateTraits climate_traits_ = []() -> climate::ClimateTraits {
-    climate::ClimateTraits ct = climate::ClimateTraits();
+    private:
+      // Default climate_traits for MITP
+      climate::ClimateTraits climate_traits_ = []() -> climate::ClimateTraits
+      {
+        climate::ClimateTraits ct = climate::ClimateTraits();
 
-    ct.set_supports_action(true);
-    ct.set_supports_current_temperature(true);
-    ct.set_supports_two_point_target_temperature(false);
-    ct.set_visual_min_temperature(MITP_MIN_TEMP);
-    ct.set_visual_max_temperature(MITP_MAX_TEMP);
-    ct.set_visual_temperature_step(MITP_TEMPERATURE_STEP);
+        ct.set_supports_action(true);
+        ct.set_supports_current_temperature(true);
+        ct.set_supports_two_point_target_temperature(false);
+        ct.set_visual_min_temperature(MITP_MIN_TEMP);
+        ct.set_visual_max_temperature(MITP_MAX_TEMP);
+        ct.set_visual_temperature_step(MITP_TEMPERATURE_STEP);
 
-    return ct;
-  }();
+        return ct;
+      }();
 
-  // UARTComponent connected to heatpump
-  const uart::UARTComponent &hp_uart_;
-  // UART packet wrapper for heatpump
-  HeatpumpBridge hp_bridge_;
-  // UARTComponent connected to thermostat
-  uart::UARTComponent *ts_uart_ = nullptr;
-  // UART packet wrapper for heatpump
-  std::unique_ptr<ThermostatBridge> ts_bridge_ = nullptr;
+      // UARTComponent connected to heatpump
+      const uart::UARTComponent &hp_uart_;
+      // UART packet wrapper for heatpump
+      HeatpumpBridge hp_bridge_;
+      // UARTComponent connected to thermostat
+      uart::UARTComponent *ts_uart_ = nullptr;
+      // UART packet wrapper for heatpump
+      std::unique_ptr<ThermostatBridge> ts_bridge_ = nullptr;
 
-  // Are we connected to the heatpump?
-  bool hp_connected_ = false;
-  // Should we call publish on the next update?
-  bool publish_on_update_ = false;
-  // Are we still discovering information about the device?
-  bool in_discovery_ = true;
-  // Number of times update() has been called in discovery mode
-  size_t discovery_updates_ = 0;
+      // Are we connected to the heatpump?
+      bool hp_connected_ = false;
+      // Should we call publish on the next update?
+      bool publish_on_update_ = false;
+      // Are we still discovering information about the device?
+      bool in_discovery_ = true;
+      // Number of times update() has been called in discovery mode
+      size_t discovery_updates_ = 0;
 
-  optional<CapabilitiesResponsePacket> capabilities_cache_;
-  bool capabilities_requested_ = false;
-  // Have we received at least one RunState response?
-  bool run_state_received_ = false;
+      optional<CapabilitiesResponsePacket> capabilities_cache_;
+      bool capabilities_requested_ = false;
+      // Have we received at least one RunState response?
+      bool run_state_received_ = false;
 
 // Time Source
 #ifdef USE_TIME
-  time::RealTimeClock *time_source_ = nullptr;
+      time::RealTimeClock *time_source_ = nullptr;
 #endif
 
-  // Listener-sensors
-  std::vector<MITPListener *> listeners_{};
-  template<typename T> void alert_listeners_(const T &packet) const {
-    for (auto *listener : this->listeners_) {
-      listener->process_packet(packet);
-    }
-  }
+      // Listener-sensors
+      std::vector<MITPListener *> listeners_{};
+      template <typename T>
+      void alert_listeners_(const T &packet) const
+      {
+        for (auto *listener : this->listeners_)
+        {
+          listener->process_packet(packet);
+        }
+      }
 
-  // Temperature select extras
-  std::string current_temperature_source_;
-  uint32_t last_received_temperature_ = millis();
-  bool temperature_source_timeout_ = false;  // Has the current source timed out?
+      // Temperature select extras
+      std::string current_temperature_source_;
+      uint32_t last_received_temperature_ = millis();
+      bool temperature_source_timeout_ = false; // Has the current source timed out?
 
-  void send_if_active_(const Packet &packet);
-  bool active_mode_ = true;
+      // used to track whether to support/handle the enhanced MHK protocol packets
+      bool enhanced_mhk_support_ = false;
 
-  // used to track whether to support/handle the enhanced MHK protocol packets
-  bool enhanced_mhk_support_ = false;
+      // If enabled, switching modes will recall target mode's previous setpoint
+      bool recall_setpoint_ = false;
+      // Array stores a float setpoint for each climate mode up to DRY.
+      std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_;
 
-  // If enabled, switching modes will recall target mode's previous setpoint
-  bool recall_setpoint_ = false;
-  // Array stores a float setpoint for each climate mode up to DRY.
-  std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_;
+      MHKState mhk_state_;
 
-  MHKState mhk_state_;
+      // Preferences
+      void save_preferences_();
+      void restore_preferences_();
+      ESPPreferenceObject preferences_;
+    };
 
-  // Preferences
-  void save_preferences_();
-  void restore_preferences_();
-  ESPPreferenceObject preferences_;
-};
+    struct MITPPreferences
+    {
+      // Array stores a float setpoint for each climate mode up to DRY.
+      std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints;
+    };
 
-struct MITPPreferences {
-  // Array stores a float setpoint for each climate mode up to DRY.
-  std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints;
-};
-
-}  // namespace mitsubishi_itp
-}  // namespace esphome
+  } // namespace mitsubishi_itp
+} // namespace esphome


### PR DESCRIPTION
Removes the ability to set active/passive mode.  This was originally intended as a debug tool, but is making some logic more complicated.  If this functionality is needed later, it can be added as a separate component or purely in ESPHome configuration.