### PR TITLE
Remote temp fix

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -256,14 +256,9 @@ void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
 void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-  // Only send this temperature packet to the heatpump if Thermostat is the selected source,
-  // or we're in passive mode (since in passive mode we're not generating any packets to
-  // set the temperature) otherwise just respond to the thermostat to keep it happy.
-  if (current_temperature_source_ == TEMPERATURE_SOURCE_THERMOSTAT) {
-    route_packet_(packet);
-  } else {
-    ts_bridge_->send_packet(SetResponsePacket());
-  }
+  // Immediately respond to thermostat (to keep it happy), and we'll send this info
+  // to the heat pump in temperature_source_report()
+  ts_bridge_->send_packet(SetResponsePacket());
   alert_listeners_(packet);
 
   float t = packet.get_remote_temperature();

--- a/components/mitsubishi_itp/sensor/mitp_sensor.h
+++ b/components/mitsubishi_itp/sensor/mitp_sensor.h
@@ -37,6 +37,11 @@ class ThermostatTemperatureSensor : public MITPSensor {
   void process_packet(const RemoteTemperatureSetRequestPacket &packet) {
     mitp_sensor_state_ = packet.get_remote_temperature();
   }
+  void publish() override {
+    // Always publish thermostat temperature readings so that we can manage
+    // time between reports in the ESPHome config
+    publish_state(mitp_sensor_state_);
+  }
 };
 
 }  // namespace mitsubishi_itp


### PR DESCRIPTION
Two changes to improve behavior on some systems (like PMFY-P06NBMU-ER5) and with some thermostats (like pac-sdw01rc-1). Shouldn't have any noticeable impact on other systems:
- When thermostat reports a temperature, ESP will immediately respond with success even before sending an update to the heat pump.
- Force-publish thermostat temperature sensor every time the thermostat reports a temperature (even if it hasn't changed). This will *not* force HA to publish these values, but *will* trigger actions in ESPHome config code (useful for tracking how often the thermostat is publishing or tracking when it was last seen)