### PR TITLE
Fix recall to only happen if previous value set

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -78,7 +78,7 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
   } else if (call.get_mode().has_value()) {
     // If we didn't get a new target temp, but we did get a mode, use the last known target temp:
     auto previous_target = mode_recall_setpoints_[call.get_mode().value()];
-    if (previous_target > 0) {
+    if (previous_target > 0.0f) {
       ESP_LOGD(TAG, "Loading previous target temp %f", previous_target);
       target_temperature = previous_target;
       set_request_packet.set_target_temperature(previous_target);

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -201,7 +201,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // If enabled, switching modes will recall target mode's previous setpoint
   bool recall_setpoint_ = false;
   // Array stores a float setpoint for each climate mode up to DRY.
-  std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_;
+  std::array<float, MAX_RECALL_MODE_INDEX + 1> mode_recall_setpoints_ = {0.0f};
 
   MHKState mhk_state_;
 
@@ -213,7 +213,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
 struct MITPPreferences {
   // Array stores a float setpoint for each climate mode up to DRY.
-  std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints;
+  std::array<float, MAX_RECALL_MODE_INDEX + 1> modeRecallSetpoints = {0.0f};
 };
 
 }  // namespace mitsubishi_itp


### PR DESCRIPTION
This should fix #5 and #12 .
I was not properly initializing `mode_recall_setpoints_` and comparing a float to an integer using `>`; I think the former was the root cause of weird setpoint values being detected as `> 0` and being recalled, but the latter fix doesn't hurt.