### PR TITLE
Logging Temp Improvements

### DIFF
--- a/components/mitsubishi_itp/mitp_bridge.cpp
+++ b/components/mitsubishi_itp/mitp_bridge.cpp
@@ -9,10 +9,9 @@ MITPBridge::MITPBridge(uart::UARTComponent *uart_component, PacketProcessor *pac
 // The heatpump loop expects responses for most sent packets, so it tracks the last send packet and wait for a response
 void HeatpumpBridge::loop() {
   // Try to get a packet
-  if (optional<RawPacket> pkt = receive_raw_packet_(SourceBridge::HEATPUMP,
-                                                    packet_awaiting_response_.has_value()
-                                                        ? packet_awaiting_response_.value().get_controller_association()
-                                                        : ControllerAssociation::MITP)) {
+  if (optional<RawPacket> pkt = receive_raw_packet_(
+          SourceBridge::HEATPUMP, packet_awaiting_response_ ? packet_awaiting_response_->get_controller_association()
+                                                            : ControllerAssociation::MITP)) {
     ESP_LOGV(BRIDGE_TAG, "Parsing %x heatpump packet", pkt.value().get_packet_type());
     // Check the packet's checksum and either process it, or log an error
     if (pkt.value().is_checksum_valid()) {
@@ -26,29 +25,28 @@ void HeatpumpBridge::loop() {
     // If there was a packet waiting for a response, remove it.
     // TODO: This incoming packet wasn't *nessesarily* a response, but for now
     // it's probably not worth checking to make sure it matches.
-    if (packet_awaiting_response_.has_value()) {
+    if (packet_awaiting_response_) {
       packet_awaiting_response_.reset();
     }
-  } else if (!packet_awaiting_response_.has_value() && !pkt_queue_.empty()) {
+  } else if (!packet_awaiting_response_ && !pkt_queue_.empty()) {
     // If we're not waiting for a response and there's a packet in the queue...
 
-    // If the packet expects a response, add it to the awaitingResponse variable
-    if (pkt_queue_.front().is_response_expected()) {
-      packet_awaiting_response_ = pkt_queue_.front();
-    }
-
-    ESP_LOGV(BRIDGE_TAG, "Sending to heatpump %s", pkt_queue_.front().to_string().c_str());
-    write_raw_packet_(pkt_queue_.front().raw_packet());
+    ESP_LOGV(BRIDGE_TAG, "Sending to heatpump %s", pkt_queue_.front()->to_string().c_str());
+    write_raw_packet_(pkt_queue_.front()->raw_packet());
     packet_sent_millis_ = millis();
 
-    // Remove packet from queue
+    // If the packet expects a response, *move* it to the awaitingResponse variable
+    if (pkt_queue_.front()->is_response_expected()) {
+      packet_awaiting_response_ = std::move(pkt_queue_.front());
+    }
+
+    // Remove (now empty!) packet pointer from queue
     pkt_queue_.pop();
-  } else if (packet_awaiting_response_.has_value() && (millis() - packet_sent_millis_ > RESPONSE_TIMEOUT_MS)) {
+  } else if (packet_awaiting_response_ && (millis() - packet_sent_millis_ > RESPONSE_TIMEOUT_MS)) {
     // We've been waiting too long for a response, give up
     // TODO: We could potentially retry here, but that seems unnecessary
     packet_awaiting_response_.reset();
-    ESP_LOGW(BRIDGE_TAG, "Timeout waiting for response to %x packet.",
-             packet_awaiting_response_.value().get_packet_type());
+    ESP_LOGW(BRIDGE_TAG, "Timeout waiting for response to %x packet.", packet_awaiting_response_->get_packet_type());
   }
 }
 
@@ -68,22 +66,12 @@ void ThermostatBridge::loop() {
   } else if (!pkt_queue_.empty()) {
     // If there's a packet in the queue...
 
-    ESP_LOGV(BRIDGE_TAG, "Sending to thermostat %s", pkt_queue_.front().to_string().c_str());
-    write_raw_packet_(pkt_queue_.front().raw_packet());
+    ESP_LOGV(BRIDGE_TAG, "Sending to thermostat %s", pkt_queue_.front()->to_string().c_str());
+    write_raw_packet_(pkt_queue_.front()->raw_packet());
     packet_sent_millis_ = millis();
 
     // Remove packet from queue
     pkt_queue_.pop();
-  }
-}
-
-/* Queues a packet to be sent by the bridge.  If the queue is full, the packet will not be
-enqueued.*/
-void MITPBridge::send_packet(const Packet &packet_to_send) {
-  if (pkt_queue_.size() <= MAX_QUEUE_SIZE) {
-    pkt_queue_.push(packet_to_send);
-  } else {
-    ESP_LOGW(BRIDGE_TAG, "Packet queue full!  %x packet not sent.", packet_to_send.get_packet_type());
   }
 }
 

--- a/components/mitsubishi_itp/mitp_bridge.h
+++ b/components/mitsubishi_itp/mitp_bridge.h
@@ -25,6 +25,8 @@ class MITPBridge {
   /* Queues a packet to be sent by the bridge.  If the queue is full, the packet will not be
   enqueued.*/
   template<typename PacketType> void send_packet(const PacketType &packet_to_send) {
+    static_assert(std::is_base_of_v<Packet, PacketType>, "PacketType must derive from Packet");
+
     if (pkt_queue_.size() <= MAX_QUEUE_SIZE) {
       pkt_queue_.push(std::make_unique<PacketType>(packet_to_send));
     } else {

--- a/components/mitsubishi_itp/mitp_bridge.h
+++ b/components/mitsubishi_itp/mitp_bridge.h
@@ -24,11 +24,11 @@ class MITPBridge {
 
   /* Queues a packet to be sent by the bridge.  If the queue is full, the packet will not be
   enqueued.*/
-  template<typename PacketType> void send_packet(const PacketType &packet_to_send) {
-    static_assert(std::is_base_of_v<Packet, PacketType>, "PacketType must derive from Packet");
+  template<typename PType> void send_packet(const PType &packet_to_send) {
+    static_assert(std::is_base_of_v<Packet, PType>, "PType must derive from Packet");
 
     if (pkt_queue_.size() <= MAX_QUEUE_SIZE) {
-      pkt_queue_.push(std::make_unique<PacketType>(packet_to_send));
+      pkt_queue_.push(std::make_unique<PType>(packet_to_send));
     } else {
       ESP_LOGW(BRIDGE_TAG, "Packet queue full!  %x packet not sent.", packet_to_send.get_packet_type());
     }

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -270,6 +270,11 @@ void MitsubishiUART::temperature_source_report(const std::string &temperature_so
   ESP_LOGI(TAG, "Received temperature from %s of %f. (Current source: %s)", temperature_source.c_str(), v,
            selected_temperature_source_.c_str());
 
+  if (isnan(v) || v >= 63.5 || v <= -64.0) {
+    ESP_LOGW(TAG, "Temperature %f from %s is out of range and will be ignored.", v, temperature_source.c_str());
+    return;
+  }
+
   // Record report in map
   temperature_reports_[temperature_source].temperature = v;
   temperature_reports_[temperature_source].timestamp = millis();


### PR DESCRIPTION
Some minor improvements to:
- Ignore temperature reports from sensors that are out of range (they will not be processed or reset the timeout for that sensor)
- Print detailed `to_string` for *sent* packets as well as received
- Added sequence numbers to packets to make it easier to track transactions from thermostat to heat pump and back