### PR TITLE
Improve 'time' handling

### DIFF
--- a/components/mitsubishi_itp/climate.py
+++ b/components/mitsubishi_itp/climate.py
@@ -39,7 +39,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_ID): cv.declare_id(MitsubishiUART),
             cv.Required(CONF_UART_HEATPUMP): cv.use_id(uart.UARTComponent),
             cv.Optional(CONF_UART_THERMOSTAT): cv.use_id(uart.UARTComponent),
-            cv.Optional(CONF_TIME_ID): cv.use_id(time.RealTimeClock),
+            cv.OnlyWith(CONF_TIME_ID, "time"): cv.use_id(time.RealTimeClock),
             cv.Optional(
                 CONF_SUPPORTED_MODES, default=DEFAULT_CLIMATE_MODES
             ): cv.ensure_list(climate.validate_climate_mode),
@@ -105,7 +105,7 @@ async def to_code(config):
         cg.add(getattr(mitp_component, "set_time_source")(rtc_component))
     elif CONF_UART_THERMOSTAT in config and config.get(CONF_ENHANCED_MHK_SUPPORT):
         raise cv.RequiredFieldInvalid(
-            f"{CONF_TIME_ID} is required if {CONF_ENHANCED_MHK_SUPPORT} is set."
+            f"A 'time' component is required if {CONF_ENHANCED_MHK_SUPPORT} is set."
         )
 
     # Traits

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -344,15 +344,9 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
   response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
 
 #ifdef USE_TIME
-  if (this->time_source_ != nullptr) {
+  if (this->time_sync_) {
     response.set_timestamp(this->time_source_->now().timestamp);
-  } else {
-    ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-    response.set_timestamp(1704067200);  // 2024-01-01 00:00:00Z
   }
-#else
-  ESP_LOGW(TAG, "No time source specified. Cannot provide accurate time!");
-  response.set_timestamp(1704067200);  // 2024-01-01 00:00:00Z
 #endif
 
   ts_bridge_->send_packet(response);

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -30,6 +30,9 @@ void MitsubishiUART::setup() {
   preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
                                                                       fnv1_hash(App.get_compilation_time()));
   restore_preferences_();
+#ifdef USE_TIME
+  this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });
+#endif
 }
 
 void MitsubishiUART::restore_preferences_() {

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -165,6 +165,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 // Time Source
 #ifdef USE_TIME
   time::RealTimeClock *time_source_ = nullptr;
+  bool time_sync_ = false;
 #endif
 
   // Listener-sensors


### PR DESCRIPTION
* If there is a 'time' component in the configuration, its ID will be found automatically. The user only needs to specify 'time_id' in the 'climate' component if the configuration includes more than one 'time' component (which will be rare).

* Since the 'time' component will be found automatically, 'time_source_' will always be set if 'USE_TIME' is defined, so there is no need to send 'fallback' timestamps.

* The 'time' component may not have reached the 'sync' state when a StateDownload is sent to the thermostat; this is especially true for the HomeAssistant 'time' component since it won't reach 'sync' until HA has connected to the ESPHome device and HA may not even be running when the ESPHome device boots. In order to protect against sending bogus timestamps to the thermostat, add a callback so that this component will know when the time component has reached the 'sync' state.