### PR TITLE
Merge pull request #30 from muart-group/dual-temp-fix

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -131,7 +131,6 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
     ct.add_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
     ct.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-    ct.add_feature_flags(climate::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE);
     ct.set_visual_min_temperature(MITP_MIN_TEMP);
     ct.set_visual_max_temperature(MITP_MAX_TEMP);
     ct.set_visual_temperature_step(MITP_TEMPERATURE_STEP);


### PR DESCRIPTION
Remove dual-setpoint support (shouldn't have been there, just accidentally added it during last change).