### PR TITLE
fix: Update source timestamp in echo to prevent component timeout

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -160,9 +160,23 @@ void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) 
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
   route_packet_(packet);
   alert_listeners_packet_(packet);
-  // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
+
   const float old_current_temperature = current_temperature;
-  current_temperature = packet.get_current_temp();
+
+  // If we're using a remote temperature source and have valid cached data, prefer our cached value.
+  // This prevents brief temperature flickers when the heat pump reports its internal sensor during
+  // the timing gap between echo and the next query. The heat pump may briefly show its internal
+  // temp before processing the echoed remote temperature.
+  if (selected_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL &&
+      !temperature_source_timeout_ &&
+      !isnan(temperature_reports_[selected_temperature_source_].temperature)) {
+    current_temperature = temperature_reports_[selected_temperature_source_].temperature;
+    ESP_LOGV(TAG, "Using cached remote temperature %.1f (heat pump reported %.1f)",
+           current_temperature, packet.get_current_temp());
+  } else {
+    // Use what the heat pump reports (internal temp mode or during timeout)
+    current_temperature = packet.get_current_temp();
+  }
 
   publish_on_update_ |= (old_current_temperature != current_temperature);
 }

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -69,25 +69,27 @@ void MitsubishiUART::loop() {
   if (!temperature_source_timeout_ && selected_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL) {
     // if it's been too long since we got a report for our current selected source
     if (millis() - temperature_reports_[selected_temperature_source_].timestamp > temperature_source_timout_ms_) {
-      // Alert user and set heatpump to internal
-      ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
-               selected_temperature_source_.c_str(), (unsigned long) temperature_source_timout_ms_);
-      // Let listeners know we've changed to the Internal temperature source (but do not change
-      // selected_temperature_source)
-      alert_listeners_internal_temp_(true);
-      temperature_source_timeout_ = true;
-      // Send a packet to the heat pump to tell it to switch to internal temperature sensing
-      hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_use_internal_temperature(true));
-    } else if (temperature_source_echo_ms_ > 0 &&
-               millis() - temperature_source_echo_last_timestamp_ > temperature_source_echo_ms_) {
-      // If we haven't timed out, and an echo is set, check and send the last temperature for the selected source
-      if (!isnan(temperature_reports_[selected_temperature_source_].temperature)) {
-        ESP_LOGD(TAG, "Echoing last received temperature");
-        hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_remote_temperature(
-            temperature_reports_[selected_temperature_source_].temperature));
-        temperature_source_echo_last_timestamp_ = millis();
-        // Update source timestamp to prevent component-side timeout while echoing valid data
-        temperature_reports_[selected_temperature_source_].timestamp = millis();
+
+      // If an echo was configured, send that before we timeout entirely.
+      if (temperature_source_echo_ms_ > 0 &&
+                millis() - temperature_source_echo_last_timestamp_ > temperature_source_echo_ms_) {
+        // If the echos haven't timed out, and an echo is set, check and send the last temperature for the selected source
+        if (!isnan(temperature_reports_[selected_temperature_source_].temperature)) {
+          ESP_LOGD(TAG, "Echoing last received temperature");
+          hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_remote_temperature(
+              temperature_reports_[selected_temperature_source_].temperature));
+          temperature_source_echo_last_timestamp_ = millis();
+        }
+      } else {
+        // Alert user and set heatpump to internal
+        ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
+                selected_temperature_source_.c_str(), (unsigned long) temperature_source_timout_ms_);
+        // Let listeners know we've changed to the Internal temperature source (but do not change
+        // selected_temperature_source)
+        alert_listeners_internal_temp_(true);
+        temperature_source_timeout_ = true;
+        // Send a packet to the heat pump to tell it to switch to internal temperature sensing
+        hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_use_internal_temperature(true));
       }
     }
   }

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -86,6 +86,8 @@ void MitsubishiUART::loop() {
         hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_remote_temperature(
             temperature_reports_[selected_temperature_source_].temperature));
         temperature_source_echo_last_timestamp_ = millis();
+        // Update source timestamp to prevent component-side timeout while echoing valid data
+        temperature_reports_[selected_temperature_source_].timestamp = millis();
       }
     }
   }
@@ -193,7 +195,7 @@ bool MitsubishiUART::select_temperature_source(const std::string &state) {
   } else {
     // If we have a fresh temperature already, go ahead and send it immediately.
     if (millis() - temperature_reports_[selected_temperature_source_].timestamp < temperature_source_timout_ms_ &&
-        !isnan(temperature_reports_[selected_temperature_source_].timestamp)) {
+        !isnan(temperature_reports_[selected_temperature_source_].temperature)) {
       hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_remote_temperature(
           temperature_reports_[selected_temperature_source_].temperature));
       alert_listeners_internal_temp_(false);


### PR DESCRIPTION
When echo_interval is configured, the echo mechanism now updates the temperature source timestamp to prevent the component's timeout logic from triggering while valid data is being echoed.

The echo was correctly sending temperature to the heat pump but not updating temperature_reports_[].timestamp, causing the component to timeout after ~8 minutes even when actively echoing valid temperature data. This resulted in oscillation between internal and remote temperature sensing.

Also fixes isnan() check that was incorrectly applied to uint32_t timestamp instead of the float temperature value.