### PR TITLE
fix: ESPHome 2026 compatibility

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -9,7 +9,7 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
 
   // Apply fan settings
   // Prioritize a custom fan mode if it's set.
-  if (call.get_custom_fan_mode()) {
+  if (call.has_custom_fan_mode()) {
     if (call.get_custom_fan_mode() == FAN_MODE_VERYHIGH) {
       set_custom_fan_mode_(FAN_MODE_VERYHIGH);
       set_request_packet.set_fan(SettingsSetRequestPacket::FAN_4);

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -25,10 +25,12 @@ void MitsubishiUART::setup() {
   for (auto *listener : listeners_) {
     listener->setup();
   }
-  // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
+  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
+  char build_time_buffer[26];
+  App.get_build_time_string(build_time_buffer);
   preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
-                                                                      fnv1_hash(App.get_compilation_time()));
+                                                                      fnv1_hash(build_time_buffer));
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -15,10 +15,12 @@ void TemperatureSourceSelect::publish() {
 
 void TemperatureSourceSelect::setup() {
 
-  // Using App.get_compilation_time() means these will get reset each time the firmware is updated, but this
+  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
+  char build_time_buffer[26];
+  App.get_build_time_string(build_time_buffer);
   this->preferences_ =
-      global_preferences->make_preference<size_t>(this->get_object_id_hash() ^ fnv1_hash(App.get_compilation_time()));
+      global_preferences->make_preference<size_t>(this->get_object_id_hash() ^ fnv1_hash(build_time_buffer));
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {


### PR DESCRIPTION
## Summary
Fixes compilation errors with ESPHome 2026.x due to API changes.

## Changes
- **has_custom_fan_mode()**: `get_custom_fan_mode()` now returns `StringRef` instead of being usable as bool. Use `has_custom_fan_mode()` for the boolean check.
- **get_build_time_string()**: `get_compilation_time()` is deprecated. The replacement `get_build_time_string()` has a new signature requiring a buffer parameter.

## Files Modified
- `components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp` - Use `has_custom_fan_mode()` for bool check
- `components/mitsubishi_itp/mitsubishi_itp.cpp` - Use buffer-based `get_build_time_string()` API
- `components/mitsubishi_itp/select/temperature-source_select.cpp` - Use buffer-based `get_build_time_string()` API

## Testing
Successfully compiled with ESPHome 2026.1.0 on ESP32-C3 (esp-idf framework).

```
======================== [SUCCESS] Took 160.63 seconds ========================
INFO Build Info: config_hash=0xea62a01c build_time_str=2026-01-21 20:07:24 +0000
INFO Successfully compiled program.
```