### PR TITLE
Add optional MHK Fahrenheit correction mode

### DIFF
--- a/components/mitsubishi_itp/climate.py
+++ b/components/mitsubishi_itp/climate.py
@@ -22,6 +22,7 @@ CONF_UART_THERMOSTAT = "uart_thermostat"
 CONF_ENHANCED_MHK_SUPPORT = (
     "enhanced_mhk"  # EXPERIMENTAL. Will be set to default eventually.
 )
+CONF_MHK_F_CORRECTION = "mhk_fahrenheit_correction"
 CONF_RECALL_SETPOINT = "recall_setpoint"
 
 DEFAULT_POLLING_INTERVAL = "5s"
@@ -50,6 +51,7 @@ CONFIG_SCHEMA = (
                 validate_custom_fan_modes
             ),
             cv.Optional(CONF_ENHANCED_MHK_SUPPORT, default=False): cv.boolean,
+            cv.Optional(CONF_MHK_F_CORRECTION, default=False): cv.boolean,
             cv.Optional(CONF_RECALL_SETPOINT, default=False): cv.boolean,
         }
     )
@@ -125,6 +127,8 @@ async def to_code(config):
         cg.add(
             getattr(mitp_component, "set_enhanced_mhk_support")(enhanced_mhk_protocol)
         )
+    if mhk_f_correction := config.get(CONF_MHK_F_CORRECTION):
+        cg.add(getattr(mitp_component, "set_mhk_f_correction")(mhk_f_correction))
     if rs_conf := config.get(CONF_RECALL_SETPOINT):
         cg.add(getattr(mitp_component, "set_recall_setpoint")(rs_conf))
 

--- a/components/mitsubishi_itp/mitp_mhk.cpp
+++ b/components/mitsubishi_itp/mitp_mhk.cpp
@@ -1,0 +1,45 @@
+#include "mitp_mhk.h"
+#include <map>
+
+namespace esphome {
+namespace mitsubishi_itp {
+
+// Keys in this map are actual temperatures in Celcius. Values are the arbitrary "Celcius" temperatures that, once the
+// MHK's creative math is applied, will produce the closest Fahrenheit temperature to the true Celcius temperature on
+// the MHK's display. This map only contains the temperatures where Mitsubishi has gotten creative with the conversion.
+// If a temperature doesn't appear here, then the MHK should show the right Fahrenheit temperature given the actual
+// Celcius temperature.
+static const std::map<float, float> mhk_rewrite_map_ = {
+    {12.0, 12.5}, {18.0, 17.5}, {18.5, 18.0}, {19.0, 18.5}, {19.5, 19.0}, {20.5, 21.0},
+    {21.0, 21.5}, {21.5, 22.0}, {22.0, 22.5}, {28.0, 27.5}, {28.5, 28.0}, {29.0, 28.5},
+    {29.5, 29.0}, {30.0, 29.5}, {30.5, 30.0}, {31.0, 30.5}, {32.0, 32.5}};
+
+// Take a real temperature in Celcius and adjust it so that the MHK display will show the closest corresponding
+// temperature in whole degrees Fahrenheit. This will actually output a slightly different Celcius value since the
+// conversion happens internally in the MHK.
+float mhk_temp_from_actual(float actual_c) {
+  if (actual_c == NAN) {
+    return NAN;
+  }
+
+  auto match = mhk_rewrite_map_.find(actual_c);
+  return match == mhk_rewrite_map_.end() ? actual_c : match->second;
+}
+
+// Take a temperature in Celcius that came from the MHK and adjust it so that it corresponds as closely as possible to
+// the actual Fahrenheit value shown on the MHK display.
+float mhk_temp_to_actual(float mhk_c) {
+  if (mhk_c == NAN) {
+    return NAN;
+  }
+
+  for (auto iter = mhk_rewrite_map_.begin(); iter != mhk_rewrite_map_.end(); ++iter) {
+    if (iter->second == mhk_c) {
+      return iter->first;
+    }
+  }
+  return mhk_c;
+}
+
+}  // namespace mitsubishi_itp
+}  // namespace esphome

--- a/components/mitsubishi_itp/mitp_mhk.h
+++ b/components/mitsubishi_itp/mitp_mhk.h
@@ -11,5 +11,8 @@ struct MHKState {
   float heat_setpoint_ = NAN;
 };
 
+float mhk_temp_from_actual(float actual_c);
+float mhk_temp_to_actual(float mhk_c);
+
 }  // namespace mitsubishi_itp
 }  // namespace esphome

--- a/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-climatecall.cpp
@@ -96,7 +96,8 @@ void MitsubishiUART::control(const climate::ClimateCall &call) {
         this->mhk_state_.heat_setpoint_ = target_temperature;
         break;
       case climate::CLIMATE_MODE_HEAT_COOL:
-        if (this->get_traits().has_feature_flags(climate::ClimateFeature::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE)) {
+        if (this->get_traits().has_feature_flags(
+                climate::ClimateFeature::CLIMATE_SUPPORTS_TWO_POINT_TARGET_TEMPERATURE)) {
           this->mhk_state_.cool_setpoint_ = target_temperature_low;
           this->mhk_state_.heat_setpoint_ = target_temperature_high;
         } else {

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -15,6 +15,23 @@ void MitsubishiUART::route_packet_(const Packet &packet) {
   }
 }
 
+float MitsubishiUART::get_corrected_temp_for_packet_(const Packet &packet, const float temp) {
+  if (!mhk_f_correction_ || packet.get_controller_association() != ControllerAssociation::THERMOSTAT ||
+      packet.get_source_bridge() == SourceBridge::NONE) {
+    return temp;
+  }
+  if (packet.get_source_bridge() == SourceBridge::THERMOSTAT) {
+    const float corrected_temp = mhk_temp_to_actual(temp);
+    ESP_LOGV(TAG, "Fahrenheit correction: %.1fC -> %.1fC MHK to actual for %.0fF", temp, corrected_temp,
+             round(corrected_temp * 9.0f / 5.0f + 32.0f));
+    return corrected_temp;
+  }
+  const float corrected_temp = mhk_temp_from_actual(temp);
+  ESP_LOGV(TAG, "Fahrenheit correction: %.1fC -> %.1fC actual to MHK for %.0fF", temp, corrected_temp,
+           round(temp * 9.0f / 5.0f + 32.0f));
+  return corrected_temp;
+}
+
 // Packet Handlers
 void MitsubishiUART::process_packet(const Packet &packet) {
   ESP_LOGI(TAG, "Generic unhandled packet type %x received.", packet.get_packet_type());
@@ -70,20 +87,14 @@ void MitsubishiUART::process_packet(const GetRequestPacket &packet) {
 void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-  if (mhk_f_correction_) {
-    float packet_temp = packet.get_target_temp();
-    // This packet is issued by the heatpump, so it contains an actual temperature outbound to the thermostat.
-    float mhk_temp = mhk_temp_from_actual(packet_temp);
-    if (packet_temp == mhk_temp) {
-      ESP_LOGV(TAG, "Fahrenheit correction: outbound target temp %.1fC unchanged", packet_temp);
-      route_packet_(packet);
-    } else {
-      ESP_LOGV(TAG, "Fahrenheit correction: outbound target temp %.1fC -> %.1fC", packet_temp, mhk_temp);
-      route_packet_(SettingsGetResponsePacket(packet).set_target_temperature(mhk_temp));
-    }
-  } else {
+  float packet_temp = packet.get_target_temp();
+  float corrected_temp = get_corrected_temp_for_packet_(packet, packet_temp);
+  if (packet_temp == corrected_temp) {
     route_packet_(packet);
+  } else {
+    route_packet_(SettingsGetResponsePacket(packet).set_target_temperature(corrected_temp));
   }
+
   alert_listeners_packet_(packet);
 
   // Mode
@@ -173,19 +184,12 @@ void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
 void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
 
-  if (mhk_f_correction_) {
-    float packet_temp = packet.get_current_temp();
-    // This packet is a response from the heatpump that will be forwarded to the thermostat.
-    float mhk_temp = mhk_temp_from_actual(packet_temp);
-    if (packet_temp == mhk_temp) {
-      ESP_LOGV(TAG, "Fahrenheit correction: current temp %.1fC unchanged", packet_temp);
-      route_packet_(packet);
-    } else {
-      ESP_LOGV(TAG, "Fahrenheit correction: current temp %.1fC -> %.1fC", packet_temp, mhk_temp);
-      route_packet_(CurrentTempGetResponsePacket(packet).set_current_temperature(mhk_temp));
-    }
-  } else {
+  float packet_temp = packet.get_current_temp();
+  float corrected_temp = get_corrected_temp_for_packet_(packet, packet_temp);
+  if (packet_temp == corrected_temp) {
     route_packet_(packet);
+  } else {
+    route_packet_(CurrentTempGetResponsePacket(packet).set_current_temperature(corrected_temp));
   }
 
   alert_listeners_packet_(packet);
@@ -275,27 +279,18 @@ void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet) {
 }
 
 void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
-  if (mhk_f_correction_) {
-    float packet_temp = packet.get_target_temp();
-    // This packet is inbound from the thermostat when its settings change.
-    float actual_temp = mhk_temp_to_actual(packet_temp);
-    if (packet_temp == actual_temp) {
-      ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC unchanged", packet_temp);
-      route_packet_(packet);
-      alert_listeners_packet_(packet);
-    } else {
-      ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC -> %.1fC", packet_temp, actual_temp);
-      // In this case, we want to modify the packet for everyone, including listeners -- only the MHK thinks that the
-      // temperature it sent is accurate.
-      auto corrected_packet = SettingsSetRequestPacket(packet).set_target_temperature(actual_temp);
-      route_packet_(corrected_packet);
-      alert_listeners_packet_(corrected_packet);
-    }
-  } else {
+  float packet_temp = packet.get_target_temp();
+  float corrected_temp = get_corrected_temp_for_packet_(packet, packet_temp);
+
+  if (packet_temp == corrected_temp) {
     ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-    // forward this packet as-is; we're just intercepting to log.
     route_packet_(packet);
     alert_listeners_packet_(packet);
+  } else {
+    auto corrected_packet = SettingsSetRequestPacket(packet).set_target_temperature(corrected_temp);
+    ESP_LOGV(TAG, "Passing through temperature-corrected inbound %s", corrected_packet.to_string().c_str());
+    route_packet_(corrected_packet);
+    alert_listeners_packet_(corrected_packet);
   }
 }
 

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -69,7 +69,21 @@ void MitsubishiUART::process_packet(const GetRequestPacket &packet) {
 
 void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
+
+  if (mhk_f_correction_) {
+    float packet_temp = packet.get_target_temp();
+    // This packet is issued by the heatpump, so it contains an actual temperature outbound to the thermostat.
+    float mhk_temp = mhk_temp_from_actual(packet_temp);
+    if (packet_temp == mhk_temp) {
+      ESP_LOGV(TAG, "Fahrenheit correction: outbound target temp %.1fC unchanged", packet_temp);
+      route_packet_(packet);
+    } else {
+      ESP_LOGV(TAG, "Fahrenheit correction: outbound target temp %.1fC -> %.1fC", packet_temp, mhk_temp);
+      route_packet_(SettingsGetResponsePacket(packet).set_target_temperature(mhk_temp));
+    }
+  } else {
+    route_packet_(packet);
+  }
   alert_listeners_packet_(packet);
 
   // Mode
@@ -158,7 +172,22 @@ void MitsubishiUART::process_packet(const SettingsGetResponsePacket &packet) {
 
 void MitsubishiUART::process_packet(const CurrentTempGetResponsePacket &packet) {
   ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
-  route_packet_(packet);
+
+  if (mhk_f_correction_) {
+    float packet_temp = packet.get_current_temp();
+    // This packet is a response from the heatpump that will be forwarded to the thermostat.
+    float mhk_temp = mhk_temp_from_actual(packet_temp);
+    if (packet_temp == mhk_temp) {
+      ESP_LOGV(TAG, "Fahrenheit correction: current temp %.1fC unchanged", packet_temp);
+      route_packet_(packet);
+    } else {
+      ESP_LOGV(TAG, "Fahrenheit correction: current temp %.1fC -> %.1fC", packet_temp, mhk_temp);
+      route_packet_(CurrentTempGetResponsePacket(packet).set_current_temperature(mhk_temp));
+    }
+  } else {
+    route_packet_(packet);
+  }
+
   alert_listeners_packet_(packet);
   // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
   const float old_current_temperature = current_temperature;
@@ -246,10 +275,22 @@ void MitsubishiUART::process_packet(const Functions2GetResponsePacket &packet) {
 }
 
 void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
-  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
-
-  // forward this packet as-is; we're just intercepting to log.
-  route_packet_(packet);
+  if (mhk_f_correction_) {
+    float packet_temp = packet.get_target_temp();
+    // This packet is inbound from the thermostat when its settings change.
+    float actual_temp = mhk_temp_to_actual(packet_temp);
+    if (packet_temp == actual_temp) {
+      ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC unchanged", packet_temp);
+      route_packet_(packet);
+    } else {
+      ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC -> %.1fC", packet_temp, actual_temp);
+      route_packet_(SettingsSetRequestPacket(packet).set_target_temperature(actual_temp));
+    }
+  } else {
+    ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+    // forward this packet as-is; we're just intercepting to log.
+    route_packet_(packet);
+  }
   alert_listeners_packet_(packet);
 }
 

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -282,16 +282,21 @@ void MitsubishiUART::process_packet(const SettingsSetRequestPacket &packet) {
     if (packet_temp == actual_temp) {
       ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC unchanged", packet_temp);
       route_packet_(packet);
+      alert_listeners_packet_(packet);
     } else {
       ESP_LOGV(TAG, "Fahrenheit correction: inbound target temp %.1fC -> %.1fC", packet_temp, actual_temp);
-      route_packet_(SettingsSetRequestPacket(packet).set_target_temperature(actual_temp));
+      // In this case, we want to modify the packet for everyone, including listeners -- only the MHK thinks that the
+      // temperature it sent is accurate.
+      auto corrected_packet = SettingsSetRequestPacket(packet).set_target_temperature(actual_temp);
+      route_packet_(corrected_packet);
+      alert_listeners_packet_(corrected_packet);
     }
   } else {
     ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
     // forward this packet as-is; we're just intercepting to log.
     route_packet_(packet);
+    alert_listeners_packet_(packet);
   }
-  alert_listeners_packet_(packet);
 }
 
 void MitsubishiUART::process_packet(const RemoteTemperatureSetRequestPacket &packet) {

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -344,10 +344,16 @@ void MitsubishiUART::process_packet(const ThermostatStateUploadPacket &packet) {
 
   ESP_LOGV(TAG, "Processing inbound %s", packet.to_string().c_str());
 
-  if (packet.get_flags() & 0x08)
-    this->mhk_state_.heat_setpoint_ = packet.get_heat_setpoint();
-  if (packet.get_flags() & 0x10)
-    this->mhk_state_.cool_setpoint_ = packet.get_cool_setpoint();
+  // In Fahrenheit correction mode, we store the actual temp in mhk_state_ and only alter it just in time to
+  // send/receive over the wire
+  if (packet.get_flags() & 0x08) {
+    this->mhk_state_.heat_setpoint_ =
+        mhk_f_correction_ ? mhk_temp_to_actual(packet.get_heat_setpoint()) : packet.get_heat_setpoint();
+  }
+  if (packet.get_flags() & 0x10) {
+    this->mhk_state_.cool_setpoint_ =
+        mhk_f_correction_ ? mhk_temp_to_actual(packet.get_cool_setpoint()) : packet.get_cool_setpoint();
+  }
 
   ts_bridge_->send_packet(SetResponsePacket());
 }
@@ -390,8 +396,11 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
 #endif
 
   response.set_auto_mode((mode == climate::CLIMATE_MODE_HEAT_COOL || mode == climate::CLIMATE_MODE_AUTO));
-  response.set_heat_setpoint(this->mhk_state_.heat_setpoint_);
-  response.set_cool_setpoint(this->mhk_state_.cool_setpoint_);
+  // We store the actual temp in mhk_state_ and only alter it just in time to send/receive over the wire
+  response.set_heat_setpoint(mhk_f_correction_ ? mhk_temp_from_actual(this->mhk_state_.heat_setpoint_)
+                                               : this->mhk_state_.heat_setpoint_);
+  response.set_cool_setpoint(mhk_f_correction_ ? mhk_temp_from_actual(this->mhk_state_.cool_setpoint_)
+                                               : this->mhk_state_.cool_setpoint_);
 
   ts_bridge_->send_packet(response);
 }

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -22,12 +22,12 @@ float MitsubishiUART::get_corrected_temp_for_packet_(const Packet &packet, const
   }
   if (packet.get_source_bridge() == SourceBridge::THERMOSTAT) {
     const float corrected_temp = mhk_temp_to_actual(temp);
-    ESP_LOGV(TAG, "Fahrenheit correction: %.1fC -> %.1fC MHK to actual for %.0fF", temp, corrected_temp,
+    ESP_LOGV(TAG, "Fahrenheit correction: %.1fC MHK to %.1fC actual for %.0fF", temp, corrected_temp,
              round(corrected_temp * 9.0f / 5.0f + 32.0f));
     return corrected_temp;
   }
   const float corrected_temp = mhk_temp_from_actual(temp);
-  ESP_LOGV(TAG, "Fahrenheit correction: %.1fC -> %.1fC actual to MHK for %.0fF", temp, corrected_temp,
+  ESP_LOGV(TAG, "Fahrenheit correction: %.1fC actual to %.1fC MHK for %.0fF", temp, corrected_temp,
            round(temp * 9.0f / 5.0f + 32.0f));
   return corrected_temp;
 }

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -25,8 +25,8 @@ const uint8_t MITP_MIN_TEMP = 16;  // Degrees C
 const uint8_t MITP_MAX_TEMP = 31;  // Degrees C
 const float MITP_TEMPERATURE_STEP = 0.5;
 
-inline const char* TEMPERATURE_SOURCE_INTERNAL = "Internal";
-inline const char* TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+inline const char *TEMPERATURE_SOURCE_INTERNAL = "Internal";
+inline const char *TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
 const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
 
@@ -87,6 +87,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
   // Turns on or off Kumo emulation mode
   void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
+
+  // Turns on or off MHK Fahrenheit conversion correction
+  void set_mhk_f_correction(const bool enabled) { mhk_f_correction_ = enabled; }
 
   // Enables the recall setpoint feature
   void set_recall_setpoint(const bool enabled) { recall_setpoint_ = enabled; }
@@ -197,6 +200,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
   // used to track whether to support/handle the enhanced MHK protocol packets
   bool enhanced_mhk_support_ = false;
+
+  // Used to decide whether to alter temperatures when communicating with the MHK to correct fahrenheit values
+  bool mhk_f_correction_ = false;
 
   // If enabled, switching modes will recall target mode's previous setpoint
   bool recall_setpoint_ = false;

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -100,6 +100,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
  protected:
   void route_packet_(const Packet &packet);
+  float get_corrected_temp_for_packet_(const Packet &packet, const float temp);
 
   void process_packet(const Packet &packet) override;
   void process_packet(const ConnectRequestPacket &packet) override;


### PR DESCRIPTION
This PR closes #33 (as best as can be done, it seems). See the discussion there, but in summary:

- Add an optional configuration option `mhk_fahrenheit_correction` which defaults to `false`. When set to `true`, it will attempt to adjust any temperatures exchanged with the MHK such that the display will show an accurate Fahrenheit value.
- This alters both set points and current temperatures (but see caveats below).

Caveats:
- This requires muart-group/itp-packet#10
- This will always work for set points, but will only work for the current temperature when the MHK is using an external temperature source. (In the installer menus, ISU 190 needs to be set to "Indoor Unit" or presumably one of the RedLINK options if available, though I haven't tested this.) When the thermostat is using its internal temperature source, it seems to ignore anything we send it and always use its internal Fahrenheit conversion.
- The lookup table is based on the one in [the project documentation](https://muart-group.github.io/user/configuration/useful-snippets#use-mitsubishi-temperature-conversion) and the one in [echavet's firmware](https://github.com/echavet/MitsubishiCN105ESPHome/blob/fce5338c38873060febacf557492d1b6d77d5984/components/cn105/localization.h#L84). I have not had time to test that the look up table is 100% correct. Ideally, it would be good to create a virtual temperature source that can be set to output each temperature in turn so that we can make sure the display shows the expected value.