### PR TITLE
Preferences fix

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,10 +29,6 @@ void MitsubishiUART::setup() {
   for (auto *listener : listeners_) {
     listener->setup();
   }
-  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
-  // is an easy way to prevent wierd conflicts if e.g. select options change.
-  char build_time_buffer[26];
-  App.get_build_time_string(build_time_buffer);
   preferences_ = this->make_entity_preference<MITPPreferences>(MITP_PREFERENCE_VERSION);
   restore_preferences_();
 #ifdef USE_TIME

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -19,6 +19,10 @@ MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
   current_temperature = NAN;
 }
 
+// This value should be changed if the structure of the preferences object changes
+// to invalidate previously stored preferences.
+const uint MITP_PREFERENCE_VERSION = 1;
+
 // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
 // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
 void MitsubishiUART::setup() {
@@ -29,7 +33,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = this->make_entity_preference<MITPPreferences>();
+  preferences_ = this->make_entity_preference<MITPPreferences>(MITP_PREFERENCE_VERSION);
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,8 +29,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
-                                                                      fnv1_hash(build_time_buffer));
+  preferences_ = this->make_entity_preference<float>();
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,7 +29,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = this->make_entity_preference<float>();
+  preferences_ = this->make_entity_preference<MITPPreferences>();
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -18,7 +18,7 @@ void TemperatureSourceSelect::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ = this->make_entity_preference<float>();
+  this->preferences_ = this->make_entity_preference<size_t>();
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -8,7 +8,8 @@ void TemperatureSourceSelect::publish() {
   if (mitp_select_value_.has_value() && mitp_select_value_.value() != current_option()) {
     publish_state(mitp_select_value_.value());
     if (active_index().has_value()) {
-      preferences_.save(&active_index().value());
+      size_t index = active_index().value();
+      preferences_.save(&index);
     }
   }
 }

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -19,10 +19,6 @@ void TemperatureSourceSelect::publish() {
 const uint TEMP_SOURCE_SELECT_PREFERENCE_VERSION = 1;
 
 void TemperatureSourceSelect::setup() {
-  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
-  // is an easy way to prevent wierd conflicts if e.g. select options change.
-  char build_time_buffer[26];
-  App.get_build_time_string(build_time_buffer);
   this->preferences_ = this->make_entity_preference<size_t>(TEMP_SOURCE_SELECT_PREFERENCE_VERSION);
 
   size_t saved_index;

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -14,13 +14,11 @@ void TemperatureSourceSelect::publish() {
 }
 
 void TemperatureSourceSelect::setup() {
-
   // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ =
-      global_preferences->make_preference<size_t>(this->get_object_id_hash() ^ fnv1_hash(build_time_buffer));
+  this->preferences_ = this->make_entity_preference<float>();
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -14,12 +14,16 @@ void TemperatureSourceSelect::publish() {
   }
 }
 
+// This value should be changed if the structure of the preferences object changes
+// to invalidate previously stored preferences.
+const uint TEMP_SOURCE_SELECT_PREFERENCE_VERSION = 1;
+
 void TemperatureSourceSelect::setup() {
   // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ = this->make_entity_preference<size_t>();
+  this->preferences_ = this->make_entity_preference<size_t>(TEMP_SOURCE_SELECT_PREFERENCE_VERSION);
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {


### PR DESCRIPTION
Two minor preference-related fixes to address changes made in ESPHome:

- Don't pass reference to temporary value (#46)
- Use new `make_entity_preference` function and introduce separate preference versioning (this will help preferences persist between flashes better as old preferences will only be invalidated when that preference version changes) (#43)