### PR TITLE
Minor March Fixes

### DIFF
--- a/components/mitsubishi_itp/climate.py
+++ b/components/mitsubishi_itp/climate.py
@@ -117,7 +117,7 @@ async def to_code(config):
     if CONF_SUPPORTED_FAN_MODES in config:
         cg.add(traits.set_supported_fan_modes(config[CONF_SUPPORTED_FAN_MODES]))
 
-    if CONF_CUSTOM_FAN_MODES in config:
+    if CONF_CUSTOM_FAN_MODES in config and len(config[CONF_CUSTOM_FAN_MODES]) > 0:
         cg.add(traits.set_supported_custom_fan_modes(config[CONF_CUSTOM_FAN_MODES]))
 
     # Debug Settings

--- a/components/mitsubishi_itp/mitp_bridge.cpp
+++ b/components/mitsubishi_itp/mitp_bridge.cpp
@@ -46,6 +46,10 @@ void HeatpumpBridge::loop() {
     // We've been waiting too long for a response, give up
     // TODO: We could potentially retry here, but that seems unnecessary
     ESP_LOGW(BRIDGE_TAG, "Timeout waiting for response to %x packet.", packet_awaiting_response_->get_packet_type());
+    if (packet_awaiting_response_->get_packet_type() == static_cast<uint8_t>(itp_packet::PacketType::CONNECT_REQUEST)) {
+      ESP_LOGW(BRIDGE_TAG,
+               "Please check the connection to the heat pump as this often indicates a communication issue.");
+    }
     packet_awaiting_response_.reset();
   }
 }

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,10 +29,6 @@ void MitsubishiUART::setup() {
   for (auto *listener : listeners_) {
     listener->setup();
   }
-  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
-  // is an easy way to prevent wierd conflicts if e.g. select options change.
-  char build_time_buffer[26];
-  App.get_build_time_string(build_time_buffer);
   preferences_ = this->make_entity_preference<MITPPreferences>(MITP_PREFERENCE_VERSION);
   restore_preferences_();
 #ifdef USE_TIME

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -69,10 +69,10 @@ void MitsubishiUART::loop() {
   // If we're not on timeout and not on Internal
   if (!temperature_source_timeout_ && selected_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL) {
     // if it's been too long since we got a report for our current selected source
-    if (millis() - temperature_reports_[selected_temperature_source_].timestamp > temperature_source_timout_ms_) {
+    if (millis() - temperature_reports_[selected_temperature_source_].timestamp > temperature_source_timeout_ms_) {
       // Alert user and set heatpump to internal
       ESP_LOGW(TAG, "No temperature received from %s for %lu milliseconds, reverting to Internal source",
-               selected_temperature_source_.c_str(), (unsigned long) temperature_source_timout_ms_);
+               selected_temperature_source_.c_str(), (unsigned long) temperature_source_timeout_ms_);
       // Let listeners know we've changed to the Internal temperature source (but do not change
       // selected_temperature_source)
       alert_listeners_internal_temp_(true);
@@ -193,7 +193,7 @@ bool MitsubishiUART::select_temperature_source(const std::string &state) {
     hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_use_internal_temperature(true));
   } else {
     // If we have a fresh temperature already, go ahead and send it immediately.
-    if (millis() - temperature_reports_[selected_temperature_source_].timestamp < temperature_source_timout_ms_ &&
+    if (millis() - temperature_reports_[selected_temperature_source_].timestamp < temperature_source_timeout_ms_ &&
         !isnan(temperature_reports_[selected_temperature_source_].temperature)) {
       hp_bridge_.send_packet(RemoteTemperatureSetRequestPacket().set_remote_temperature(
           temperature_reports_[selected_temperature_source_].temperature));

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -19,6 +19,10 @@ MitsubishiUART::MitsubishiUART(uart::UARTComponent *hp_uart_comp)
   current_temperature = NAN;
 }
 
+// This value should be changed if the structure of the preferences object changes
+// to invalidate previously stored preferences.
+const uint MITP_PREFERENCE_VERSION = 1;
+
 // Used to restore state of previous MITP-specific settings (like temperature source or pass-thru mode)
 // Most other climate-state is preserved by the heatpump itself and will be retrieved after connection
 void MitsubishiUART::setup() {
@@ -29,7 +33,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = this->make_entity_preference<MITPPreferences>();
+  preferences_ = this->make_entity_preference<MITPPreferences>(MITP_PREFERENCE_VERSION);
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,8 +29,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = global_preferences->make_preference<MITPPreferences>(get_object_id_hash() ^
-                                                                      fnv1_hash(build_time_buffer));
+  preferences_ = this->make_entity_preference<float>();
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -29,7 +29,7 @@ void MitsubishiUART::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  preferences_ = this->make_entity_preference<float>();
+  preferences_ = this->make_entity_preference<MITPPreferences>();
   restore_preferences_();
 #ifdef USE_TIME
   this->time_source_->add_on_time_sync_callback([this] { this->time_sync_ = true; });

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -25,8 +25,8 @@ const uint8_t MITP_MIN_TEMP = 16;  // Degrees C
 const uint8_t MITP_MAX_TEMP = 31;  // Degrees C
 const float MITP_TEMPERATURE_STEP = 0.5;
 
-inline const char* TEMPERATURE_SOURCE_INTERNAL = "Internal";
-inline const char* TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
+inline const char *TEMPERATURE_SOURCE_INTERNAL = "Internal";
+inline const char *TEMPERATURE_SOURCE_THERMOSTAT = "Thermostat";
 
 const auto MAX_RECALL_MODE_INDEX = climate::ClimateMode::CLIMATE_MODE_DRY;
 
@@ -68,7 +68,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void register_listener(MITPListener *listener) { this->listeners_.push_back(listener); }
 
   // Temperature Source config
-  void set_temperature_source_timeout_ms(const uint32_t timeout) { this->temperature_source_timout_ms_ = timeout; }
+  void set_temperature_source_timeout_ms(const uint32_t timeout) { this->temperature_source_timeout_ms_ = timeout; }
   void set_temperature_source_echo_ms(const uint32_t echo_interval) {
     this->temperature_source_echo_ms_ = echo_interval;
   }
@@ -190,7 +190,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   std::string selected_temperature_source_ = TEMPERATURE_SOURCE_INTERNAL;
   bool temperature_source_timeout_ = false;  // Has the current source timed out?
   std::map<std::string, TemperatureReport> temperature_reports_;
-  uint32_t temperature_source_timout_ms_ =
+  uint32_t temperature_source_timeout_ms_ =
       420000;  // 7min default, some heat pumps revert on their own after 10min, some ~60seconds
   uint32_t temperature_source_echo_ms_ = 0;              // 0 = off by default
   uint32_t temperature_source_echo_last_timestamp_ = 0;  // Timestamp of last sent temperature

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -18,7 +18,7 @@ void TemperatureSourceSelect::setup() {
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ = this->make_entity_preference<float>();
+  this->preferences_ = this->make_entity_preference<size_t>();
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -8,7 +8,8 @@ void TemperatureSourceSelect::publish() {
   if (mitp_select_value_.has_value() && mitp_select_value_.value() != current_option()) {
     publish_state(mitp_select_value_.value());
     if (active_index().has_value()) {
-      preferences_.save(&active_index().value());
+      size_t index = active_index().value();
+      preferences_.save(&index);
     }
   }
 }

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -19,10 +19,6 @@ void TemperatureSourceSelect::publish() {
 const uint TEMP_SOURCE_SELECT_PREFERENCE_VERSION = 1;
 
 void TemperatureSourceSelect::setup() {
-  // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
-  // is an easy way to prevent wierd conflicts if e.g. select options change.
-  char build_time_buffer[26];
-  App.get_build_time_string(build_time_buffer);
   this->preferences_ = this->make_entity_preference<size_t>(TEMP_SOURCE_SELECT_PREFERENCE_VERSION);
 
   size_t saved_index;

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -14,13 +14,11 @@ void TemperatureSourceSelect::publish() {
 }
 
 void TemperatureSourceSelect::setup() {
-
   // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ =
-      global_preferences->make_preference<size_t>(this->get_object_id_hash() ^ fnv1_hash(build_time_buffer));
+  this->preferences_ = this->make_entity_preference<float>();
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {

--- a/components/mitsubishi_itp/select/temperature-source_select.cpp
+++ b/components/mitsubishi_itp/select/temperature-source_select.cpp
@@ -14,12 +14,16 @@ void TemperatureSourceSelect::publish() {
   }
 }
 
+// This value should be changed if the structure of the preferences object changes
+// to invalidate previously stored preferences.
+const uint TEMP_SOURCE_SELECT_PREFERENCE_VERSION = 1;
+
 void TemperatureSourceSelect::setup() {
   // Using App.get_build_time_string() means these will get reset each time the firmware is updated, but this
   // is an easy way to prevent wierd conflicts if e.g. select options change.
   char build_time_buffer[26];
   App.get_build_time_string(build_time_buffer);
-  this->preferences_ = this->make_entity_preference<size_t>();
+  this->preferences_ = this->make_entity_preference<size_t>(TEMP_SOURCE_SELECT_PREFERENCE_VERSION);
 
   size_t saved_index;
   if (this->preferences_.load(&saved_index) && has_index(saved_index) && at(saved_index).has_value()) {


### PR DESCRIPTION
Several minor fixes:
- Fixes #46 by not referencing a temporary variable (breaking change introduced in ESPHome 2026.3)
- Fixes #43 by introducing preferences versioning
- Fixes #32 by allowing an empty custom_fan_modes definition
- Closes #26 , hopefully, by adding a clarifying error message

Tested without issues on my MSZ units with an MHK2.