### PR TITLE
Add Zones support

### DIFF
--- a/components/mitsubishi_itp/mitp_bridge.cpp
+++ b/components/mitsubishi_itp/mitp_bridge.cpp
@@ -179,6 +179,9 @@ void MITPBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
         case GetCommand::FUNCTIONS_2:
           process_raw_packet_<Functions2GetResponsePacket>(pkt, false);
           break;
+        case GetCommand::ZONE_STATE:
+          process_raw_packet_<ZoneGetResponsePacket>(pkt, false);
+          break;
         case GetCommand::THERMOSTAT_STATE_DOWNLOAD:
           process_raw_packet_<ThermostatStateDownloadResponsePacket>(pkt, false);
           break;
@@ -202,6 +205,9 @@ void MITPBridge::classify_and_process_raw_packet_(RawPacket &pkt) const {
           break;
         case SetCommand::THERMOSTAT_STATE_UPLOAD:
           process_raw_packet_<ThermostatStateUploadPacket>(pkt, true);
+          break;
+        case SetCommand::ZONE_STATE:
+          process_raw_packet_<ZoneSetRequestPacket>(pkt, true);
           break;
         case SetCommand::THERMOSTAT_SET_AA:
           process_raw_packet_<ThermostatAASetRequestPacket>(pkt, true);

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -324,6 +324,11 @@ void MitsubishiUART::process_packet(const ThermostatAASetRequestPacket &packet) 
   ts_bridge_->send_packet(SetResponsePacket());
 }
 
+void MitsubishiUART::process_packet(const ZoneGetResponsePacket &packet) {
+  ESP_LOGV(TAG, "Processing %s", packet.to_string().c_str());
+  alert_listeners_packet_(packet);
+}
+
 void MitsubishiUART::process_packet(const SetResponsePacket &packet) {
   ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
            packet.get_result_code());

--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -329,6 +329,14 @@ void MitsubishiUART::process_packet(const ZoneGetResponsePacket &packet) {
   alert_listeners_packet_(packet);
 }
 
+void MitsubishiUART::process_packet(const ZoneSetRequestPacket &packet) {
+  ESP_LOGV(TAG, "Passing through inbound %s", packet.to_string().c_str());
+
+  // forward this packet as-is; we're just intercepting to log.
+  route_packet_(packet);
+  alert_listeners_packet_(packet);
+}
+
 void MitsubishiUART::process_packet(const SetResponsePacket &packet) {
   ESP_LOGV(TAG, "Got Set Response packet, success = %s (code = %x)", packet.is_successful() ? "true" : "false",
            packet.get_result_code());

--- a/components/mitsubishi_itp/mitsubishi_itp.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp.cpp
@@ -164,6 +164,10 @@ void MitsubishiUART::update() {
   hp_bridge_.send_packet(GetRequestPacket::get_current_temp_instance());
   hp_bridge_.send_packet(GetRequestPacket::get_error_info_instance());
 
+  if (zones_enabled_) {
+    hp_bridge_.send_packet(GetRequestPacket::get_zone_instance());
+  }
+
   if (in_discovery_) {
     // After criteria met, exit discovery mode
     // Currently this is either 5 updates or a successful RunState response.
@@ -307,6 +311,12 @@ void MitsubishiUART::temperature_source_report(const std::string &temperature_so
     // If we've sent a remote temperature, we're not using the internal one
     alert_listeners_internal_temp_(false);
   }
+}
+
+bool MitsubishiUART::set_zone_active(uint8_t zone, bool active) {
+  ESP_LOGI(TAG, "Setting zone %d to %s", zone + 1, active ? "ON" : "OFF");
+  hp_bridge_.send_packet(ZoneSetRequestPacket().set_zone_active(zone, active));
+  return true;
 }
 
 void MitsubishiUART::reset_filter_status() {

--- a/components/mitsubishi_itp/mitsubishi_itp.h
+++ b/components/mitsubishi_itp/mitsubishi_itp.h
@@ -85,6 +85,10 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   // Button triggers
   void reset_filter_status();
 
+  // Zone control
+  bool set_zone_active(uint8_t zone, bool active);
+  void set_zones_enabled(bool enabled) { zones_enabled_ = enabled; }
+
   // Turns on or off Kumo emulation mode
   void set_enhanced_mhk_support(const bool supports) { enhanced_mhk_support_ = supports; }
 
@@ -117,6 +121,7 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
   void process_packet(const ThermostatHelloPacket &packet) override;
   void process_packet(const ThermostatStateUploadPacket &packet) override;
   void process_packet(const ThermostatAASetRequestPacket &packet) override;
+  void process_packet(const ZoneGetResponsePacket &packet) override;
   void process_packet(const SetResponsePacket &packet) override;
 
   void handle_thermostat_state_download_request(const GetRequestPacket &packet) override;
@@ -197,6 +202,9 @@ class MitsubishiUART : public PollingComponent, public climate::Climate, public 
 
   // used to track whether to support/handle the enhanced MHK protocol packets
   bool enhanced_mhk_support_ = false;
+
+  // set to true when at least one zone switch is registered
+  bool zones_enabled_ = false;
 
   // If enabled, switching modes will recall target mode's previous setpoint
   bool recall_setpoint_ = false;

--- a/components/mitsubishi_itp/switch/__init__.py
+++ b/components/mitsubishi_itp/switch/__init__.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import CONF_ID
+from esphome.core import coroutine
+
+from ...mitsubishi_itp import CONF_MITSUBISHI_ITP_ID, MitsubishiUART, mitsubishi_itp_ns
+
+MITPZoneSwitch = mitsubishi_itp_ns.class_("MITPZoneSwitch", switch.Switch)
+
+ZONE_SWITCH_SCHEMA = switch.switch_schema(
+    MITPZoneSwitch,
+    icon="mdi:hvac",
+)
+
+ZONES = {f"zone_{i}": ZONE_SWITCH_SCHEMA for i in range(1, 9)}
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_MITSUBISHI_ITP_ID): cv.use_id(MitsubishiUART),
+    }
+).extend(
+    {cv.Optional(zone_key): ZONE_SWITCH_SCHEMA for zone_key in ZONES}
+)
+
+
+@coroutine
+async def to_code(config):
+    mitp_component = await cg.get_variable(config[CONF_MITSUBISHI_ITP_ID])
+
+    zones_registered = False
+
+    for zone_key in ZONES:
+        if zone_conf := config.get(zone_key):
+            zone_component = cg.new_Pvariable(zone_conf[CONF_ID])
+
+            # Derive 0-based zone index from key name (zone_1 -> 0, zone_2 -> 1, ...)
+            zone_number = int(zone_key.split("_")[1]) - 1
+            cg.add(getattr(zone_component, "set_zone_number")(zone_number))
+
+            await cg.register_parented(zone_component, mitp_component)
+            await switch.register_switch(zone_component, zone_conf)
+
+            cg.add(getattr(mitp_component, "register_listener")(zone_component))
+            zones_registered = True
+
+    if zones_registered:
+        cg.add(getattr(mitp_component, "set_zones_enabled")(True))

--- a/components/mitsubishi_itp/switch/mitp_switch.h
+++ b/components/mitsubishi_itp/switch/mitp_switch.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "../mitsubishi_itp.h"
+
+namespace esphome {
+namespace mitsubishi_itp {
+
+class MITPZoneSwitch : public switch_::Switch, public Parented<MitsubishiUART>, public MITPListener {
+ public:
+  MITPZoneSwitch() = default;
+  using Parented<MitsubishiUART>::Parented;
+
+  void set_zone_number(uint8_t zone) { zone_ = zone; }
+
+  void process_packet(const ZoneGetResponsePacket &packet) override {
+    zone_state_ = packet.get_zone_active(zone_);
+  }
+
+  void publish() override {
+    if (zone_state_.has_value() && zone_state_.value() != state) {
+      publish_state(zone_state_.value());
+    }
+  }
+
+ protected:
+  void write_state(bool state) override {
+    if (parent_->set_zone_active(zone_, state)) {
+      zone_state_ = state;
+      publish_state(state);
+    }
+  }
+
+ private:
+  uint8_t zone_ = 0;  // Zero-based zone index
+  optional<bool> zone_state_;
+};
+
+}  // namespace mitsubishi_itp
+}  // namespace esphome


### PR DESCRIPTION
This commit add the necessary pieces to support controlling Zone actuators that are often found in ducted heat pump units.

The magic for how the zones are controlled was documented in an issue comment here:
  https://github.com/SwiCago/HeatPump/issues/39#issuecomment-1250024905

This commit depends on the corresponding commit in the itp-packet repository which adds support for packet type 0x15 for zone control.

Zone support is enabled if the zones are configured in the ESPHome YAML with a config that may look like this:

```
switch:
  - platform: mitsubishi_itp
    zone_1:
      name: Play Room
    zone_2:
      name: Master Bedroom
    zone_3:
      name: Guest Bedroom
    zone_4:
      name: Kids Bedrooms
```
These units can support 4 and 8 zone configurations, but I have only tested up to 4, which is all I have on my system.