### PR TITLE
v1: Fix MHK2 wall clock — send bit-packed local time, not raw UTC epoch

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetprocessing.cpp
@@ -401,10 +401,19 @@ void MitsubishiUART::handle_thermostat_state_download_request(const GetRequestPa
 
 #ifdef USE_TIME
   if (this->time_sync_) {
-    response.set_timestamp(this->time_source_->now().timestamp);
+    // The MHK2 expects this field as a bit-packed LOCAL date/time, not a raw UTC epoch:
+    //   ((year-2017)<<26)|(month<<22)|(day<<17)|(hour<<12)|(minute<<6)|second
+    // (set_timestamp() byte-swaps the value; the thermostat decodes it with the above layout.)
+    // Sending now().timestamp (a UTC epoch) makes the MHK2 clock wrong and drift. See issue #63.
+    auto t = this->time_source_->now();
+    int32_t encoded = ((int32_t) (t.year - 2017) << 26) | ((int32_t) t.month << 22) |
+                      ((int32_t) t.day_of_month << 17) | ((int32_t) t.hour << 12) |
+                      ((int32_t) t.minute << 6) | ((int32_t) t.second);
+    response.set_timestamp((time_t) encoded);
   } else {
     ESP_LOGW(TAG, "Time source is not synchronized. Cannot provide accurate time!");
-    response.set_timestamp(1704067200);  // 2024-01-01 00:00:00Z
+    // 2024-01-01 00:00:00, bit-packed to match the layout above.
+    response.set_timestamp((time_t) (((int32_t) (2024 - 2017) << 26) | ((int32_t) 1 << 22) | ((int32_t) 1 << 17)));
   }
 #endif
 


### PR DESCRIPTION
Fixes #63.

### Problem
With `enhanced_mhk`, the thermostat time field is set from `now().timestamp` (a UTC epoch), but the MHK2 decodes those 4 bytes as a **bit-packed LOCAL date/time**:

```
((year-2017)<<26)|(month<<22)|(day<<17)|(hour<<12)|(minute<<6)|second
```

so a raw epoch renders as a wrong, *drifting* wall clock (decode in #63: epoch `1784755980` = `0x6A61370C` → `19:28`, and the low bits advance as seconds mod 64, hence the drift).

### Fix
Build the bit-packed value from the tz-aware local `now()` and pass it to the existing `set_timestamp()` (which byte-swaps and writes it). Single-file change on the `v1` line; the time-not-synced fallback is bit-packed the same way.

This is the minimal v1 surface. `v2` already solves it more cleanly via `get_timestruct()` + `itp-packet`'s `set_timestamp(tm)` — happy to instead mirror that split here if you'd prefer.

### Testing
Verified on 11 mITP boards (MHK2 attached, °F, `enhanced_mhk: true`): after flashing, the MHK2 wall clocks read correct local time and stay correct (DST rules come from the board's timezone).

---
*Transparency: this fix was investigated and prepared with AI assistance; the full decode/analysis is in #63 so it can be independently verified.*
