### PR TITLE
Fix ping-ponging of reported temperature when off

### DIFF
--- a/components/mitsubishi_itp/mitsubishi_itp-packetreceiving.cpp
+++ b/components/mitsubishi_itp/mitsubishi_itp-packetreceiving.cpp
@@ -119,9 +119,19 @@ void MitsubishiUART::receive_packet(const CurrentTempGetResponsePacket &packet) 
 
   float packet_temp = packet.get_current_temp();
 
-  // This will be the same as the remote temperature if we're using a remote sensor, otherwise the internal temp
+  // It appears that some heat pumps will forget that we told them to use an
+  // external temperature when they're switched off, and report their internal
+  // temperature. Ignore their output in this case.
+  if (mode == climate::CLIMATE_MODE_OFF && !temperature_source_timeout_ &&
+      selected_temperature_source_ != TEMPERATURE_SOURCE_INTERNAL) {
+    const auto report = temperature_reports_.find(selected_temperature_source_);
+    if (report != temperature_reports_.end() && !isnan(report->second.temperature)) {
+      packet_temp = report->second.temperature;
+    }
+  }
+
   const float old_current_temperature = current_temperature;
-  current_temperature = packet.get_current_temp();
+  current_temperature = packet_temp;
 
   publish_on_update_ |= (old_current_temperature != current_temperature);
 


### PR DESCRIPTION
It looks like some models of heat pump ignore remote temperature setting when off, reporting their internal temperature instead. This leads to our reported temperature to ping-pong between the internal temperature and the external temperature source.

One of my air handlers is in my attic, so without this patch, I get these ridiculous looking graphs in home assistant:
<img width="945" height="629" alt="image" src="https://github.com/user-attachments/assets/ab58441c-1c65-438f-936c-da4c83bbb172" />
